### PR TITLE
restore contract metadata

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+echo "pre-commit: checking generated contract docs are up to date..."
+node scripts/contracts/generate-pages.mjs --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Generated reconciliation artifacts (intermediate outputs)
+data/contracts-inline-decisions.json
+data/contracts-address-reconciliation.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,15 +120,30 @@ Before opening a PR, run:
 mint validate
 ```
 
-If your change is broad (navigation changes, many links, structural edits), also run:
+Also run:
 
 ```bash
-mint build
+mint broken-links
+mint a11y
 ```
 
 Fix any errors before opening your PR.
 
-### 7. Commit and Push
+### 7. Contract Address Source Of Truth
+
+Contract addresses are managed through a single source of truth:
+
+- `data/contracts.json`
+
+Do not manually edit generated canonical address pages. Instead:
+
+```bash
+node scripts/contracts/generate-pages.mjs
+```
+
+This regenerates contract snippets and canonical deployed-contract pages from `data/contracts.json`.
+
+### 8. Commit and Push
 
 - Commit with a clear message, e.g. `Fix typo in BEX swap guide` or `Add section on pool exits`.
 - Keep the scope of each PR focused (one topic or one section is ideal).
@@ -139,7 +154,7 @@ git commit -m "Your message"
 git push origin fix/your-change
 ```
 
-### 8. Open a Pull Request
+### 9. Open a Pull Request
 
 - Open a PR from your branch to `berachain/docs` **main**.
 - Fill in the PR template (description, checklist).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for considering contributing. This guide will help you get set up and submit changes.
 
+For environment setup and local tooling commands, use [README.md](README.md). `CONTRIBUTING.md` focuses on contribution workflow and review expectations.
+
 ## Code of Conduct
 
 Berachain has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct. We expect everyone to follow it. Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before contributing.
@@ -66,18 +68,9 @@ cd docs
 git remote add upstream https://github.com/berachain/docs
 ```
 
-### 2. Prerequisites
+Use the setup and local run instructions in [README.md](README.md).
 
-- **Node.js** 16 or newer
-- **npm** or **yarn**
-
-### 3. Install Mintlify CLI
-
-```bash
-npm i -g mint
-```
-
-### 4. Create a Branch
+### 2. Create a Branch
 
 Work on a branch (do not commit directly to `main`):
 
@@ -85,24 +78,14 @@ Work on a branch (do not commit directly to `main`):
 git checkout -b fix/your-change   # or feature/your-feature
 ```
 
-### 5. Run the Docs Locally
-
-From the repo root:
-
-```bash
-mint dev
-```
-
-Open [http://localhost:3000](http://localhost:3000). Check that your changes look correct and that existing pages still work.
-
-### 6. Add or Edit Content
+### 3. Add or Edit Content
 
 - **Editing:** Open the relevant `.mdx` file under `general/`, `build/`, or `reference/` and edit.
 - **New page:** Create the `.mdx` file in the right folder, then add it to `docs.json` (see [Adding or moving pages](#adding-or-moving-pages)).
 
 Use existing pages as a style reference. Prefer clear, concise language and short paragraphs. Use MDX components where they add value (see [Content guidelines](#content-guidelines)).
 
-### 7. Adding or Moving Pages
+### 4. Adding or Moving Pages
 
 Navigation is defined in `docs.json` under `navigation.tabs`. Each tab has `groups`; each group has a `group` name and a `pages` array of file paths (without `.mdx`).
 
@@ -120,17 +103,24 @@ To add a new page:
 
 To move or rename a page, update both the file path and every reference in `docs.json` and in other docs (links).
 
-### 8. Content Guidelines
+### 5. Content Guidelines
 
 - Follow the structure and tone of existing docs.
+- Use US English spelling in prose (`color`, `behavior`, `favor`, `labeled`).
 - Use Mintlify/MDX components where appropriate, e.g. `<Card>`, `<Steps>`, `<Note>`, `<Tip>`, `<Warning>`.
 - Use fenced code blocks with a language tag where you show code.
 - Link to related pages when it helps the reader.
-- After editing, run `mint dev` and click through to confirm links and formatting.
+- Validate your changes locally (see [README.md](README.md) for commands).
 
-### 9. Build Check
+### 6. Validation Before PR
 
-Before submitting, run a production build to catch broken links or invalid config:
+Before opening a PR, run:
+
+```bash
+mint validate
+```
+
+If your change is broad (navigation changes, many links, structural edits), also run:
 
 ```bash
 mint build
@@ -138,7 +128,7 @@ mint build
 
 Fix any errors before opening your PR.
 
-### 10. Commit and Push
+### 7. Commit and Push
 
 - Commit with a clear message, e.g. `Fix typo in BEX swap guide` or `Add section on pool exits`.
 - Keep the scope of each PR focused (one topic or one section is ideal).
@@ -149,7 +139,7 @@ git commit -m "Your message"
 git push origin fix/your-change
 ```
 
-### 11. Open a Pull Request
+### 8. Open a Pull Request
 
 - Open a PR from your branch to `berachain/docs` **main**.
 - Fill in the PR template (description, checklist).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,18 @@ Do not manually edit generated canonical address pages. Instead:
 node scripts/contracts/generate-pages.mjs
 ```
 
-This regenerates contract snippets and canonical deployed-contract pages from `data/contracts.json`.
+This regenerates:
+
+- snippets in `snippets/contracts/generated/`
+- canonical deployed-contract pages in:
+  - `build/getting-started/deployed-contracts.mdx`
+  - `build/bex/deployed-contracts.mdx`
+  - `build/bend/deployed-contracts.mdx`
+  - `build/bend/deployed-markets.mdx`
+
+Check in generated outputs with your `data/contracts.json` changes in the same PR.
+
+At the moment this generation step is manual (not CI-enforced), so treat regeneration + check-in as required whenever contract data changes.
 
 ### 8. Commit and Push
 

--- a/build/bend/deployed-contracts.mdx
+++ b/build/bend/deployed-contracts.mdx
@@ -1,7 +1,9 @@
 ---
 title: "Deployed Contracts"
-description: "Bend smart contract addresses on Berachain mainnet; Morpho, IRM, oracles, URD, and related contracts."
+description: "Bend smart contract addresses on Berachain; Morpho, IRM, oracles, URD, and related contracts."
 ---
+
+import BendContractsTable from "/snippets/contracts/generated/bend-contracts-table.mdx";
 
 Addresses for reading from or writing to Bend contracts. ABIs are in [berachain/doc-abis](https://github.com/berachain/doc-abis).
 
@@ -9,29 +11,4 @@ Addresses for reading from or writing to Bend contracts. ABIs are in [berachain/
 Deployed contracts have been audited by multiple parties. Reports are on [GitHub](https://github.com/berachain/security-audits).
 </Note>
 
-## Morpho
-
-| Name | Mainnet Address |
-| --- | --- |
-| **Morpho (Vault)** | [0x24147243f9c08d835C218Cda1e135f8dFD0517D0](https://berascan.com/address/0x24147243f9c08d835C218Cda1e135f8dFD0517D0) |
-| **Adaptive Curve IRM** | [0xcf247Df3A2322Dea0D408f011c194906E77a6f62](https://berascan.com/address/0xcf247Df3A2322Dea0D408f011c194906E77a6f62) |
-| **Bundler3** | [0xF920140A65D0f412f2AB3e76C4fEAB5Eef0657ae](https://berascan.com/address/0xF920140A65D0f412f2AB3e76C4fEAB5Eef0657ae) |
-| **General Adapter 1** | [0xd2B9667F5214115E27937C410cAeE83E3a901Df7](https://berascan.com/address/0xd2B9667F5214115E27937C410cAeE83E3a901Df7) |
-| **Meta Morpho V1.1** | N/A |
-| **Meta Morpho Factory V1.1** | [0x5EDd48C6ACBd565Eeb31702FD9fa9Cbc86fbE616](https://berascan.com/address/0x5EDd48C6ACBd565Eeb31702FD9fa9Cbc86fbE616) |
-| **Meta Fee Partitioner** | [0x80108Ee81A92091Db6B8B2326B1875ce9388f461](https://berascan.com/address/0x80108Ee81A92091Db6B8B2326B1875ce9388f461) |
-| **Public Allocator** | [0xB62F34Ab315eaDeAc698e8EaEB6Fc2650951BFe7](https://berascan.com/address/0xB62F34Ab315eaDeAc698e8EaEB6Fc2650951BFe7) |
-| **Morpho Chainlink Oracle V2** | N/A |
-| **Morpho Chainlink Oracle V2 Factory** | [0xAf2FDC54f7bc9d6e8C2D2760E908f4e1beB04d9E](https://berascan.com/address/0xAf2FDC54f7bc9d6e8C2D2760E908f4e1beB04d9E) |
-| **Universal Reward Distributer (URD)** | N/A |
-| **Universal Reward Distributer (URD) Factory** | [0x46fE2bc33b661E01A8946BbC3Bf43F2B8382d802](https://berascan.com/address/0x46fE2bc33b661E01A8946BbC3Bf43F2B8382d802) |
-
-## Vaults
-
-<Note>
-More vaults may be deployed, please check [https://bend.berachain.com/lend](https://bend.berachain.com/lend) for the latest deployed vaults.
-</Note>
-
-| Name | Mainnet Address |
-| --- | --- |
-| **Re7 Honey Vault** | [0x30BbA9CD9Eb8c95824aa42Faa1Bb397b07545bc1](https://berascan.com/address/0x30BbA9CD9Eb8c95824aa42Faa1Bb397b07545bc1) |
+<BendContractsTable />

--- a/build/bend/deployed-markets.mdx
+++ b/build/bend/deployed-markets.mdx
@@ -3,18 +3,13 @@ title: "Deployed Markets"
 description: "Market IDs and parameters for deployed Bend lending markets on Berachain."
 ---
 
+import BendMarketsTable from "/snippets/contracts/generated/bend-markets-table.mdx";
+
 Market IDs deployed on Bend. For the latest whitelisted markets, see [bend.berachain.com/borrow](https://bend.berachain.com/borrow).
 
 ## Market IDs
 
-| Market | ID |
-| --- | --- |
-| **WBTC / HONEY** | `0x950962c1cf2591f15806e938bfde9b5f9fbbfcc5fb640030952c08b536f1f167` |
-| **sUSDe / HONEY** | `0x1ba7904c73d337c39cb88b00180dffb215fc334a6ff47bbe829cd9ee2af00c97` |
-| **wgBERA / HONEY** | `0x63c2a7c20192095c15d1d668ccce6912999b01ea60eeafcac66eca32015674dd` |
-| **WETH / HONEY** | `0x1f05d324f604bd1654ec040311d2ac4f5820ecfd1801a3d19d2c6f09d4f7a614` |
-| **WBERA / HONEY** | `0x147b032db82d765b9d971eac37c8176260dde0fe91f6a542f20cdd9ede1054df` |
-| **iBERA / HONEY** | `0x594de722a090f8d0df41087c23e2187fb69d9cd6b7b425c6dd56ddc1cff545f0` |
+<BendMarketsTable />
 
 To find a market ID, open [bend.berachain.com/borrow](https://bend.berachain.com/borrow) and read the Market ID from the URL.
 

--- a/build/bex/deployed-contracts.mdx
+++ b/build/bex/deployed-contracts.mdx
@@ -3,6 +3,8 @@ title: "Deployed Contracts"
 description: "Registry of deployed BEX contract addresses by network."
 ---
 
+import BexContractsTable from "/snippets/contracts/generated/bex-contracts-table.mdx";
+
 <Warning>
 On January 21st, 2025, Balancer disclosed a long-standing vulnerability in their V2 Vault implementation. BEX incorporates contract logic from Balancer V2 and shares the same vulnerability. Exercise additional caution when creating new pools, particularly when including **untrusted or newly-created tokens**.
 
@@ -19,36 +21,4 @@ The following is a list of contract addresses for interacting with Berachain BEX
 A full list of contract ABIs can be found at [github.com/berachain/doc-abis](https://github.com/berachain/doc-abis).
 </Tip>
 
-## Mainnet contracts
-
-| Name | Address | ABI |
-| ---- | ------- | --- |
-| Vault | [`0x4Be03f781C497A489E3cB0287833452cA9B9E80B`](https://berascan.com/address/0x4Be03f781C497A489E3cB0287833452cA9B9E80B) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IVault.abi.json) |
-| ProtocolFeesCollector | [`0xB8Cf46Cf1b1476E707619913a70B2085d26f1707`](https://berascan.com/address/0xB8Cf46Cf1b1476E707619913a70B2085d26f1707) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesCollector.abi.json) |
-| BalancerHelpers | [`0x5083737EC75a728c265BE578C9d0d5333a2c5951`](https://berascan.com/address/0x5083737EC75a728c265BE578C9d0d5333a2c5951) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerHelpers.abi.json) |
-| PoolCreationHelper | [`0x55dccE8165C88aAd4403a15A9cE3A8E244657dD2`](https://berascan.com/address/0x55dccE8165C88aAd4403a15A9cE3A8E244657dD2) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IPoolCreationHelper.abi.json) |
-| ProtocolFeesWithdrawer | [`0x1635F0E1B3e8A6713d03aE155ba79458Ba3240C7`](https://berascan.com/address/0x1635F0E1B3e8A6713d03aE155ba79458Ba3240C7) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesWithdrawer.abi.json) |
-| ComposableStablePoolFactory | [`0xDfA30BDa0375d4763711AB0CC8D91B20bfCC87E1`](https://berascan.com/address/0xDfA30BDa0375d4763711AB0CC8D91B20bfCC87E1) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IComposableStablePoolFactory.abi.json) |
-| BatchRelayerLibrary | [`0xCB4AE3030bA06F7EEE54A7B96AfcA7457f9525cf`](https://berascan.com/address/0xCB4AE3030bA06F7EEE54A7B96AfcA7457f9525cf) | |
-| BatchRelayerQueryLibrary | [`0x4151083172b2CEFB83A33fD7FC9F6cBabb3Fd08d`](https://berascan.com/address/0x4151083172b2CEFB83A33fD7FC9F6cBabb3Fd08d) | |
-| BalancerRelayer | [`0x6044f181aB5E9C05A4ed9Ce295f3B178d2492EE7`](https://berascan.com/address/0x6044f181aB5E9C05A4ed9Ce295f3B178d2492EE7) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerRelayer.abi.json) |
-| WeightedPoolFactory | [`0xa966fA8F2d5B087FFFA499C0C1240589371Af409`](https://berascan.com/address/0xa966fA8F2d5B087FFFA499C0C1240589371Af409) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IWeightedPoolFactory.abi.json) |
-| ProtocolFeePercentagesProvider | [`0x33C88ffdEe710ed3908C791137Bd1D4421AabBBf`](https://berascan.com/address/0x33C88ffdEe710ed3908C791137Bd1D4421AabBBf) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeePercentagesProvider.abi.json) |
-| BalancerQueries | [`0x3C612e132624f4Bd500eE1495F54565F0bcc9b59`](https://berascan.com/address/0x3C612e132624f4Bd500eE1495F54565F0bcc9b59) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerQueries.abi.json) |
-
-## Bepolia testnet contracts
-
-| Name | Address | ABI |
-| ---- | ------- | --- |
-| Vault | [`0x708cA656b68A6b7384a488A36aD33505a77241FE`](https://berascan.com/address/0x708cA656b68A6b7384a488A36aD33505a77241FE) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IVault.abi.json) |
-| ProtocolFeesCollector | [`0x05A607aCf3548E84DD1E44c3706F850c849058Da`](https://berascan.com/address/0x05A607aCf3548E84DD1E44c3706F850c849058Da) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesCollector.abi.json) |
-| BalancerHelpers | [`0xC7c981ADcDC5d48fed0CD52807fb2bAB22676C8f`](https://berascan.com/address/0xC7c981ADcDC5d48fed0CD52807fb2bAB22676C8f) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerHelpers.abi.json) |
-| PoolCreationHelper | [`0x0dC9964F6CA33d9EF38DEB4925234766127C6B36`](https://berascan.com/address/0x0dC9964F6CA33d9EF38DEB4925234766127C6B36) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IPoolCreationHelper.abi.json) |
-| ProtocolFeesWithdrawer | [`0x8c2D77f0CfcD4Af9cF41494EfE500FE324012c06`](https://berascan.com/address/0x8c2D77f0CfcD4Af9cF41494EfE500FE324012c06) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesWithdrawer.abi.json) |
-| ComposableStablePoolFactory | [`0xB60DbBaCEaeC23486a64d12089F467ef949f1bb1`](https://berascan.com/address/0xB60DbBaCEaeC23486a64d12089F467ef949f1bb1) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IComposableStablePoolFactory.abi.json) |
-| BatchRelayerLibrary | [`0xfD772657FC8c4Ed3884AfF151b680883814052FA`](https://berascan.com/address/0xfD772657FC8c4Ed3884AfF151b680883814052FA) | |
-| BatchRelayerQueryLibrary | [`0x263a1C5B2c5851beA2177eb8D6caefdfF2A25601`](https://berascan.com/address/0x263a1C5B2c5851beA2177eb8D6caefdfF2A25601) | |
-| BalancerRelayer | [`0x343215E156Ff586711a5B8C49Fe3099BAF22624C`](https://berascan.com/address/0x343215E156Ff586711a5B8C49Fe3099BAF22624C) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerRelayer.abi.json) |
-| WeightedPoolFactory | [`0xf1d23276C7b271B2aC595C78977b2312E9954D57`](https://berascan.com/address/0xf1d23276C7b271B2aC595C78977b2312E9954D57) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IWeightedPoolFactory.abi.json) |
-| ProtocolFeePercentagesProvider | [`0x8119E412E00fe3c857739E95dB147817Bf615dB8`](https://berascan.com/address/0x8119E412E00fe3c857739E95dB147817Bf615dB8) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeePercentagesProvider.abi.json) |
-| BalancerQueries | [`0xE3723383a0EA73D5c0dE424BAA97F97f86f6cF92`](https://berascan.com/address/0xE3723383a0EA73D5c0dE424BAA97F97f86f6cF92) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerQueries.abi.json) |
+<BexContractsTable />

--- a/build/getting-started/deployed-contracts.mdx
+++ b/build/getting-started/deployed-contracts.mdx
@@ -3,6 +3,8 @@ title: "Deployed Contract Addresses"
 description: "Berachain core contract addresses by network."
 ---
 
+import CoreContractsTable from "/snippets/contracts/generated/core-contracts-table.mdx";
+
 This is a list of addresses where you can read from or write to these contracts.
 
 > A full list of Contract ABIs can be found at https://github.com/berachain/doc-abis
@@ -12,48 +14,4 @@ Various parties have audited the deployed contracts.
 All audit reports are publicly available on [Github](https://github.com/berachain/security-audits).
 </Info>
 
-## Mainnet contracts
-
-### Proof of Liquidity
-
-| Name | Mainnet Address |
-|------|-----------------|
-| BGT Token | `0x656b95E550C07a9ffe548bd4085c72418Ceb1dba` |
-| BeraChef | `0xfb81E39E3970076ab2693fA5C45A07Cc724C93c2` |
-| BlockRewardController | `0x2B6e40f65D82A0cB98795bC7587a71bfa49fBB2B` |
-| Distributor | `0x1b4854DE16279B3d6b37b0a28Abe36A53374A1Cd` |
-| FeeCollector | `0xD435F3e35EEd75C1c21952B8Bc45D0159a2593C9` |
-| RewardVaultFactory | `0x94Ad6Ac84f6C6FbA8b8CCbD71d9f4f101def52a8` |
-| BGTStaker | `0x791fb02A77Ca787EFf6d5e7e83691f76DB55F96F` |
-| Governance | `0x24a4B37F9c40fB0E80ec436Df2e9989FBAFa8bB7` |
-| Timelock | `0x50bfF7b88f97c1cB37d6CfCB518A20b306Aa7355` |
-
-### Tokens
-
-| Name | Mainnet Address |
-|------|-----------------|
-| WBERA | `0x6969696969696969696969696969696969696969` |
-| HONEY | `0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce` |
-| HoneyFactory | `0xA81F0019d442f19f66880bcf2698B4E5D5Ec249A` |
-
-### Other
-
-| Name | Mainnet Address |
-|------|-----------------|
-| BeaconDeposit | `0x4242424242424242424242424242424242424242` |
-| Create2 | `0x4e59b44847b379578588920cA78FbF26c0B4956C` |
-| Multicall3 | `0xcA11bde05977b3631167028862bE2a173976CA11` |
-| Permit2 | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
-
-## NFT contracts
-
-Berachain NFT contract addresses on both Ethereum (via LayerZero adapters) and Berachain.
-
-| Collection | Ethereum Adapter | Berachain Address |
-|------------|------------------|-------------------|
-| Bong Bears | `0x1897C001341F81Ca72154b75b882aE708e06bF48` | `0x141De07E5D4C4759EC9301DA106115D4841f66cD` |
-| Bond Bears | `0x6b1C374105467d1fC1090C989BcbbCC172c8a89c` | `0xA0CF472E6132F6B822a944f6F31aA7b261c7c375` |
-| Boo Bears | `0x7591992F1a98636C6B7207f30382ca4Bec83D9Be` | `0xf49ec5db255854C4a567de5AB3826c9AAbaFc7cF` |
-| Baby Bears | `0xc48C54e92d135B356DD0CbF50F803A8c8d38968b` | `0xDDeAf391c4be2d01ca52aBb8C159a06820ef078C` |
-| Band Bears | `0x392Faa1b0EF108ded69897Ba5382E909C39Fc09e` | `0x7711B2Eb2451259dbF211e30157ceB7CFeb79a19` |
-| Bit Bears | `0x3EB12398753eEd7E8747321c37C85De30d8E2e94` | `0x72D876D9cdf4001b836f8E47254d0551EdA2eebB` |
+<CoreContractsTable />

--- a/build/getting-started/deployed-contracts.mdx
+++ b/build/getting-started/deployed-contracts.mdx
@@ -7,7 +7,7 @@ import CoreContractsTable from "/snippets/contracts/generated/core-contracts-tab
 
 This is a list of addresses where you can read from or write to these contracts.
 
-> A full list of Contract ABIs can be found at https://github.com/berachain/doc-abis
+> A full list of Contract ABIs can be found at https://github.com/berachain/abis
 
 <Info>
 Various parties have audited the deployed contracts.

--- a/build/guides/ai-developer.mdx
+++ b/build/guides/ai-developer.mdx
@@ -35,6 +35,6 @@ Core references (network, RPC, chain IDs, deployed addresses, ABIs): [Developer 
 - **Contract addresses / ABIs / network config** → “Use the Berachain **Deployed contracts** page” or “What’s the RPC and chain ID for Berachain mainnet in the docs?”
 - **Verify a contract** → “Follow the Berachain **Verifying smart contracts** guide” or “How do I verify with Hardhat/Forge on Berascan?”
 - **A specific integration** → Name the stack and, if relevant, the guide: “Using the **Pyth Oracle** guide on Berachain, how do I call `updatePrice`?” or “From the **LayerZero OFT** guide, what’s the exact deploy order?”
-- **Chain and network** → Say “Berachain mainnet” or “Berachain testnet / Artio” so the AI picks the right RPC, faucet, and addresses.
+- **Chain and network** → Say “Berachain mainnet” or “Berachain testnet (Bepolia)” so the AI picks the right RPC, faucet, and addresses.
 
 The **Guides** dropdown (under Community Developers) lists each example; each guide page includes a raw README link so MCP can fetch the full repo README when needed.

--- a/build/guides/community-guides.mdx
+++ b/build/guides/community-guides.mdx
@@ -41,8 +41,6 @@ This page lists community developer guides and example projects for Berachain. E
 | Index & Query Berachain Data with Goldsky | [Repo](https://github.com/berachain/guides/tree/main/apps/goldsky-subgraph) | [Guide](/build/guides/community/goldsky-subgraph) |
 | Index & Query Berachain Data with The Graph | [Guide](https://thegraph.com/docs/en/subgraphs/quick-start/) | — |
 | Envio Indexer ERC20 | [Repo](https://github.com/berachain/guides/tree/main/apps/envio-indexer-erc20) | [Guide](/build/guides/community/envio-indexer-erc20) |
-| Index & Query Berachain Data with SubQuery | [Guide](https://subquery.network/doc/indexer/quickstart/quickstart_chains/berachain-artio-testnet.html#berachain-artio-testnet-quick-start) | — |
-
 ## Verifiable Randomness
 
 | Project | GitHub | Guide |

--- a/build/guides/community/ethers6-solc-helloworld.mdx
+++ b/build/guides/community/ethers6-solc-helloworld.mdx
@@ -13,7 +13,7 @@ Use this guide when you want to **deploy a simple contract** using **Ethers.js v
 ## Requirements
 
 - Node, npm
-- Wallet with testnet $BERA (e.g. [Artio Faucet](https://artio.faucet.berachain.com))
+- Wallet with testnet $BERA (e.g. [Bepolia Faucet](https://bepolia.faucet.berachain.com))
 
 ## Stack
 

--- a/build/guides/community/foundry-erc20.mdx
+++ b/build/guides/community/foundry-erc20.mdx
@@ -13,7 +13,7 @@ Use this guide when you want to **create and deploy an ERC20 token** on Berachai
 ## Requirements
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation) (`foundryup`)
-- Wallet with testnet $BERA (e.g. [Artio Faucet](https://artio.faucet.berachain.com))
+- Wallet with testnet $BERA (e.g. [Bepolia Faucet](https://bepolia.faucet.berachain.com))
 
 ## Stack
 
@@ -26,7 +26,7 @@ Foundry, Solidity, ERC20.
    git clone https://github.com/berachain/guides.git && cd guides/apps/foundry-erc20
    forge build
    ```
-2. Set `PRIVATE_KEY` and RPC (e.g. `https://bartio.rpc.berachain.com/`) in env or `--rpc-url`.
+2. Set `PRIVATE_KEY` and RPC (e.g. `https://bepolia.rpc.berachain.com/`) in env or `--rpc-url`.
 3. Deploy with `forge create` or a script; use `cast` to interact. Exact commands are in the README.
 
 For full deploy and test commands, fetch the [raw README](https://raw.githubusercontent.com/berachain/guides/main/apps/foundry-erc20/README.md).

--- a/build/guides/community/gelato-vrf.mdx
+++ b/build/guides/community/gelato-vrf.mdx
@@ -17,7 +17,7 @@ Use this guide when you need **verifiable on-chain randomness** (e.g. for games,
 ## Requirements
 
 - Node `v20.0.0` or greater, npm or yarn
-- Wallet with $BERA — [bArtio Faucet](https://bartio.faucet.berachain.com)
+- Wallet with $BERA — [Bepolia Faucet](https://bepolia.faucet.berachain.com)
 - Hardhat
 
 ## Stack
@@ -37,7 +37,7 @@ Solidity, Hardhat, Node.js, Gelato VRF (requester + fulfillment).
    npx hardhat deploy --network berachain
    ```
    Note the deployed address from `deployments/` and set `SC_ADDRESS` in `.env`.
-4. **Create a Gelato VRF task** at [app.gelato.network/vrf](https://app.gelato.network/vrf): choose **Berachain bArtio**, enter your requester contract address, then launch the VRF instance.
+4. **Create a Gelato VRF task** at [app.gelato.network/vrf](https://app.gelato.network/vrf): choose **Berachain Bepolia**, enter your requester contract address, then launch the VRF instance.
 5. **Request randomness**
    ```bash
    npx hardhat run ./scripts/requestRandomness.ts --network berachain

--- a/build/guides/community/hardhat-viem-helloworld.mdx
+++ b/build/guides/community/hardhat-viem-helloworld.mdx
@@ -13,7 +13,7 @@ Use this guide when you want to **set up Hardhat with Viem** for Berachain, **de
 ## Requirements
 
 - Node `v18.18.2+`, npm
-- MetaMask (or other wallet) with $BERA — use [Berachain testnet faucet](https://bartio.faucet.berachain.com) or similar
+- MetaMask (or other wallet) with $BERA — use [Berachain testnet faucet](https://bepolia.faucet.berachain.com) or similar
 
 ## Stack
 

--- a/build/guides/community/layerzero-oft.mdx
+++ b/build/guides/community/layerzero-oft.mdx
@@ -17,7 +17,7 @@ Use this guide when you want to **bridge an existing ERC20** from another chain 
 ## Requirements
 
 - Node `v20.11.0` or greater, npm
-- Wallet with Berachain testnet $BERA — [bArtio Faucet](https://bartio.faucet.berachain.com)
+- Wallet with Berachain testnet $BERA — [Bepolia Faucet](https://bepolia.faucet.berachain.com)
 - Wallet with Sepolia $UNI (or other source token) — see README for faucet/Uniswap
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 
@@ -40,7 +40,7 @@ Solidity, Foundry (Forge scripts), Node.js, LayerZero V2 OFT.
    Set `SEPOLIA_ADAPTER_ADDRESS` in `.env`.
 4. **Deploy OFT on Berachain**
    ```bash
-   forge script script/MyOFT.s.sol --rpc-url https://bartio.rpc.berachain.com/ --broadcast
+   forge script script/MyOFT.s.sol --rpc-url https://bepolia.rpc.berachain.com/ --broadcast
    ```
    Set `BERACHAIN_OFT_ADDRESS` in `.env`.
 5. **Bridge tokens**

--- a/build/guides/community/pyth-entropy.mdx
+++ b/build/guides/community/pyth-entropy.mdx
@@ -17,7 +17,7 @@ Use this guide when you need **on-chain verifiable randomness** or **provably fa
 ## Requirements
 
 - Node `v20.11.0` or greater, npm
-- Wallet with Berachain testnet $BERA — [Artio Faucet](https://artio.faucet.berachain.com)
+- Wallet with Berachain testnet $BERA — [Bepolia Faucet](https://bepolia.faucet.berachain.com)
 - [Foundry](https://book.getfoundry.sh/getting-started/installation) (`foundryup`)
 
 ## Stack

--- a/build/guides/community/pyth-oracle.mdx
+++ b/build/guides/community/pyth-oracle.mdx
@@ -18,7 +18,7 @@ Use this guide when you need **real-time price data** or **oracle feeds** on Ber
 
 - Node `v20.11.0` or greater, npm
 - [jq](https://jqlang.github.io/jq/download/)
-- Wallet with testnet $BERA — [Artio Faucet](https://artio.faucet.berachain.com)
+- Wallet with testnet $BERA — [Bepolia Faucet](https://bepolia.faucet.berachain.com)
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
 
 ## Stack
@@ -32,18 +32,18 @@ Solidity, Foundry (Forge, Cast), Node.js, Pyth Hermes API (price payloads).
    git clone https://github.com/berachain/guides.git && cd guides/apps/pyth-oracle
    npm install
    ```
-2. **Import wallet** (Foundry keystore): `cast wallet import deployer --interactive`. Set `BERACHAIN_ARTIO_RPC` (e.g. `https://rpc.ankr.com/berachain_testnet`).
+2. **Import wallet** (Foundry keystore): `cast wallet import deployer --interactive`. Set `BERACHAIN_TESTNET_RPC` (e.g. `https://bepolia.rpc.berachain.com`).
 3. **Deploy consumer contract**
    ```bash
    forge build
-   forge create ./src/ConsumerContract.sol:ConsumerContract --rpc-url $BERACHAIN_ARTIO_RPC --account deployer
+   forge create ./src/ConsumerContract.sol:ConsumerContract --rpc-url $BERACHAIN_TESTNET_RPC --account deployer
    ```
 4. **Fetch price and update on-chain**
    ```bash
    curl -s "https://hermes.pyth.network/v2/updates/price/latest?&ids[]=0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace" | jq -r ".binary.data[0]" > price_update.txt
-   cast send <CONTRACT> --rpc-url $BERACHAIN_ARTIO_RPC "updatePrice(bytes[])" "[0x\`cat price_update.txt\`]" --account deployer --value 0.0001ether
+   cast send <CONTRACT> --rpc-url $BERACHAIN_TESTNET_RPC "updatePrice(bytes[])" "[0x\`cat price_update.txt\`]" --account deployer --value 0.0001ether
    ```
-5. **Read price:** `cast call <CONTRACT> --rpc-url $BERACHAIN_ARTIO_RPC "getPrice()"`
+5. **Read price:** `cast call <CONTRACT> --rpc-url $BERACHAIN_TESTNET_RPC "getPrice()"`
 
 **Troubleshooting:** `StalePrice` — re-run the update; `InsufficientFee` — increase `--value` (e.g. `0.0005ether`).
 

--- a/build/guides/community/viem-solc-helloworld.mdx
+++ b/build/guides/community/viem-solc-helloworld.mdx
@@ -13,7 +13,7 @@ Use this guide when you want to **deploy a simple contract** using **Viem** and 
 ## Requirements
 
 - Node, npm
-- Wallet with testnet $BERA (e.g. [Artio Faucet](https://artio.faucet.berachain.com))
+- Wallet with testnet $BERA (e.g. [Bepolia Faucet](https://bepolia.faucet.berachain.com))
 
 ## Stack
 

--- a/data/contracts.json
+++ b/data/contracts.json
@@ -1,0 +1,422 @@
+{
+  "metadata": {
+    "sourceOfTruth": "Single source for deployed contract references in docs",
+    "networks": [
+      "berachainMainnet",
+      "berachainBepolia"
+    ]
+  },
+  "pol": {
+    "bgtToken": {
+      "name": "BGT Token",
+      "address": {
+        "berachainMainnet": "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba",
+        "berachainBepolia": "0x656b95E550C07a9ffe548bd4085c72418Ceb1dba"
+      }
+    },
+    "berachef": {
+      "name": "BeraChef",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/pol/rewards/BeraChef.json",
+      "address": {
+        "berachainMainnet": "0xdf960E8F3F19C481dDE769edEDD439ea1a63426a",
+        "berachainBepolia": "0xdf960E8F3F19C481dDE769edEDD439ea1a63426a"
+      }
+    },
+    "blockRewardController": {
+      "name": "BlockRewardController",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/pol/rewards/BlockRewardController.json",
+      "address": {
+        "berachainMainnet": "0x2B6e40f65D82A0cB98795bC7587a71bfa49fBB2B",
+        "berachainBepolia": "0x1AE7dD7AE06F6C58B4524d9c1f816094B1bcCD8e"
+      }
+    },
+    "distributor": {
+      "name": "Distributor",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/pol/rewards/Distributor.json",
+      "address": {
+        "berachainMainnet": "0x1b4854DE16279B3d6b37b0a28Abe36A53374A1Cd",
+        "berachainBepolia": "0xD2f19a79b026Fb636A7c300bF5947df113940761"
+      }
+    },
+    "feeCollector": {
+      "name": "FeeCollector",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/pol/FeeCollector.json",
+      "address": {
+        "berachainMainnet": "0xD435F3e35EEd75C1c21952B8Bc45D0159a2593C9",
+        "berachainBepolia": "0x7bb8DdaC7FbE3FFC0f4B3c73C4F158B06CF82650"
+      }
+    },
+    "rewardVaultFactory": {
+      "name": "RewardVaultFactory",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/pol/rewards/RewardVaultFactory.json",
+      "address": {
+        "berachainMainnet": "0x94Ad6Ac84f6C6FbA8b8CCbD71d9f4f101def52a8",
+        "berachainBepolia": "0x94Ad6Ac84f6C6FbA8b8CCbD71d9f4f101def52a8"
+      }
+    },
+    "bgtStaker": {
+      "name": "BGTStaker",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/pol/BGTStaker.json",
+      "address": {
+        "berachainMainnet": "0x791fb02A77Ca787EFf6d5e7e83691f76DB55F96F",
+        "berachainBepolia": "0x44F07Ce5AfeCbCC406e6beFD40cc2998eEb8c7C6"
+      }
+    },
+    "governance": {
+      "name": "Governance",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/gov/BerachainGovernance.json",
+      "address": {
+        "berachainMainnet": "0x24a4B37F9c40fB0E80ec436Df2e9989FBAFa8bB7",
+        "berachainBepolia": "0x4f4A5c2194B8e856b7a05B348F6ba3978FB6f6D5"
+      }
+    },
+    "timelock": {
+      "name": "Timelock",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/gov/TimeLock.json",
+      "address": {
+        "berachainMainnet": "0x50bfF7b88f97c1cB37d6CfCB518A20b306Aa7355",
+        "berachainBepolia": "0xb5f2000b5744f207c931526cAE2134cAa8b6862a"
+      }
+    }
+  },
+  "tokens": {
+    "wbera": {
+      "name": "WBERA",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/WBERA.json",
+      "address": {
+        "berachainMainnet": "0x6969696969696969696969696969696969696969",
+        "berachainBepolia": "0x6969696969696969696969696969696969696969"
+      }
+    },
+    "honey": {
+      "name": "HONEY",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/honey/Honey.json",
+      "address": {
+        "berachainMainnet": "0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce",
+        "berachainBepolia": "0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce"
+      }
+    },
+    "honeyFactory": {
+      "name": "HoneyFactory",
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts/honey/HoneyFactory.json",
+      "address": {
+        "berachainMainnet": "0xA81F0019d442f19f66880bcf2698B4E5D5Ec249A",
+        "berachainBepolia": "0xA4aFef880F5cE1f63c9fb48F661E27F8B4216401"
+      }
+    }
+  },
+  "other": {
+    "beaconDeposit": {
+      "name": "BeaconDeposit",
+      "address": {
+        "berachainMainnet": "0x4242424242424242424242424242424242424242",
+        "berachainBepolia": "0x4242424242424242424242424242424242424242"
+      }
+    },
+    "create2": {
+      "name": "Create2",
+      "abi": "",
+      "address": {
+        "berachainMainnet": "0x4e59b44847b379578588920cA78FbF26c0B4956C",
+        "berachainBepolia": "0x4e59b44847b379578588920cA78FbF26c0B4956C"
+      }
+    },
+    "multicall3": {
+      "name": "Multicall3",
+      "abi": "https://github.com/mds1/multicall/releases/download/v3.1.0/Multicall3.json",
+      "address": {
+        "berachainMainnet": "0xcA11bde05977b3631167028862bE2a173976CA11",
+        "berachainBepolia": "0xcA11bde05977b3631167028862bE2a173976CA11"
+      }
+    },
+    "permit2": {
+      "name": "Permit2",
+      "abi": "https://github.com/Uniswap/permit2-sdk/blob/main/abis/Permit2.json",
+      "address": {
+        "berachainMainnet": "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+        "berachainBepolia": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
+      }
+    }
+  },
+  "nfts": {
+    "bongBears": {
+      "name": "Bong Bears",
+      "address": {
+        "ethereumMainnet": "0x1897C001341F81Ca72154b75b882aE708e06bF48",
+        "berachainMainnet": "0x141De07E5D4C4759EC9301DA106115D4841f66cD"
+      }
+    },
+    "bondBears": {
+      "name": "Bond Bears",
+      "address": {
+        "ethereumMainnet": "0x6b1C374105467d1fC1090C989BcbbCC172c8a89c",
+        "berachainMainnet": "0xA0CF472E6132F6B822a944f6F31aA7b261c7c375"
+      }
+    },
+    "booBears": {
+      "name": "Boo Bears",
+      "address": {
+        "ethereumMainnet": "0x7591992F1a98636C6B7207f30382ca4Bec83D9Be",
+        "berachainMainnet": "0xf49ec5db255854C4a567de5AB3826c9AAbaFc7cF"
+      }
+    },
+    "babyBears": {
+      "name": "Baby Bears",
+      "address": {
+        "ethereumMainnet": "0xc48C54e92d135B356DD0CbF50F803A8c8d38968b",
+        "berachainMainnet": "0xDDeAf391c4be2d01ca52aBb8C159a06820ef078C"
+      }
+    },
+    "bandBears": {
+      "name": "Band Bears",
+      "address": {
+        "ethereumMainnet": "0x392Faa1b0EF108ded69897Ba5382E909C39Fc09e",
+        "berachainMainnet": "0x7711B2Eb2451259dbF211e30157ceB7CFeb79a19"
+      }
+    },
+    "bitBears": {
+      "name": "Bit Bears",
+      "address": {
+        "ethereumMainnet": "0x3EB12398753eEd7E8747321c37C85De30d8E2e94",
+        "berachainMainnet": "0x72D876D9cdf4001b836f8E47254d0551EdA2eebB"
+      }
+    }
+  },
+  "bex": {
+    "vault": {
+      "name": "Vault",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IVault.abi.json",
+      "address": {
+        "berachainMainnet": "0x4Be03f781C497A489E3cB0287833452cA9B9E80B",
+        "berachainBepolia": "0x708cA656b68A6b7384a488A36aD33505a77241FE"
+      }
+    },
+    "protocolFeesCollector": {
+      "name": "ProtocolFeesCollector",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesCollector.abi.json",
+      "address": {
+        "berachainMainnet": "0xB8Cf46Cf1b1476E707619913a70B2085d26f1707",
+        "berachainBepolia": "0x05A607aCf3548E84DD1E44c3706F850c849058Da"
+      }
+    },
+    "balancerHelpers": {
+      "name": "BalancerHelpers",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IBalancerHelpers.abi.json",
+      "address": {
+        "berachainMainnet": "0x5083737EC75a728c265BE578C9d0d5333a2c5951",
+        "berachainBepolia": "0xC7c981ADcDC5d48fed0CD52807fb2bAB22676C8f"
+      }
+    },
+    "poolCreationHelper": {
+      "name": "PoolCreationHelper",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IPoolCreationHelper.abi.json",
+      "address": {
+        "berachainMainnet": "0x55dccE8165C88aAd4403a15A9cE3A8E244657dD2",
+        "berachainBepolia": "0x0dC9964F6CA33d9EF38DEB4925234766127C6B36"
+      }
+    },
+    "protocolFeesWithdrawer": {
+      "name": "ProtocolFeesWithdrawer",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesWithdrawer.abi.json",
+      "address": {
+        "berachainMainnet": "0x1635F0E1B3e8A6713d03aE155ba79458Ba3240C7",
+        "berachainBepolia": "0x8c2D77f0CfcD4Af9cF41494EfE500FE324012c06"
+      }
+    },
+    "stablePoolFactory": {
+      "name": "ComposableStablePoolFactory",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IComposableStablePoolFactory.abi.json",
+      "address": {
+        "berachainMainnet": "0xDfA30BDa0375d4763711AB0CC8D91B20bfCC87E1",
+        "berachainBepolia": "0xB60DbBaCEaeC23486a64d12089F467ef949f1bb1"
+      }
+    },
+    "batchRelayerLibrary": {
+      "name": "BatchRelayerLibrary",
+      "abi": "",
+      "address": {
+        "berachainMainnet": "0xCB4AE3030bA06F7EEE54A7B96AfcA7457f9525cf",
+        "berachainBepolia": "0xfD772657FC8c4Ed3884AfF151b680883814052FA"
+      }
+    },
+    "batchRelayerQueryLibrary": {
+      "name": "BatchRelayerQueryLibrary",
+      "abi": "",
+      "address": {
+        "berachainMainnet": "0x4151083172b2CEFB83A33fD7FC9F6cBabb3Fd08d",
+        "berachainBepolia": "0x263a1C5B2c5851beA2177eb8D6caefdfF2A25601"
+      }
+    },
+    "balancerRelayer": {
+      "name": "BalancerRelayer",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IBalancerRelayer.abi.json",
+      "address": {
+        "berachainMainnet": "0x6044f181aB5E9C05A4ed9Ce295f3B178d2492EE7",
+        "berachainBepolia": "0x343215E156Ff586711a5B8C49Fe3099BAF22624C"
+      }
+    },
+    "weightedPoolFactory": {
+      "name": "WeightedPoolFactory",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IWeightedPoolFactory.abi.json",
+      "address": {
+        "berachainMainnet": "0xa966fA8F2d5B087FFFA499C0C1240589371Af409",
+        "berachainBepolia": "0xf1d23276C7b271B2aC595C78977b2312E9954D57"
+      }
+    },
+    "protocolFeePercentagesProvider": {
+      "name": "ProtocolFeePercentagesProvider",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeePercentagesProvider.abi.json",
+      "address": {
+        "berachainMainnet": "0x33C88ffdEe710ed3908C791137Bd1D4421AabBBf",
+        "berachainBepolia": "0x8119E412E00fe3c857739E95dB147817Bf615dB8"
+      }
+    },
+    "balancerQueries": {
+      "name": "BalancerQueries",
+      "abi": "https://github.com/berachain/doc-abis/blob/main/bex/IBalancerQueries.abi.json",
+      "address": {
+        "berachainMainnet": "0x3C612e132624f4Bd500eE1495F54565F0bcc9b59",
+        "berachainBepolia": "0xE3723383a0EA73D5c0dE424BAA97F97f86f6cF92"
+      }
+    }
+  },
+  "bend": {
+    "morpho": {
+      "name": "Morpho (Vault)",
+      "address": {
+        "berachainMainnet": "0x24147243f9c08d835C218Cda1e135f8dFD0517D0",
+        "berachainBepolia": ""
+      }
+    },
+    "adaptiveCurveIrm": {
+      "name": "Adaptive Curve IRM",
+      "address": {
+        "berachainMainnet": "0xcf247Df3A2322Dea0D408f011c194906E77a6f62",
+        "berachainBepolia": ""
+      }
+    },
+    "bundler3": {
+      "name": "Bundler3",
+      "address": {
+        "berachainMainnet": "0xF920140A65D0f412f2AB3e76C4fEAB5Eef0657ae",
+        "berachainBepolia": ""
+      }
+    },
+    "generalAdapter1": {
+      "name": "General Adapter 1",
+      "address": {
+        "berachainMainnet": "0xd2B9667F5214115E27937C410cAeE83E3a901Df7",
+        "berachainBepolia": ""
+      }
+    },
+    "metaMorphoV1_1": {
+      "name": "Meta Morpho V1.1",
+      "address": {
+        "berachainMainnet": "",
+        "berachainBepolia": ""
+      }
+    },
+    "metaMorphoFactoryV1_1": {
+      "name": "Meta Morpho Factory V1.1",
+      "address": {
+        "berachainMainnet": "0x5EDd48C6ACBd565Eeb31702FD9fa9Cbc86fbE616",
+        "berachainBepolia": ""
+      }
+    },
+    "metaFeePartitioner": {
+      "name": "Meta Fee Partitioner",
+      "address": {
+        "berachainMainnet": "0x80108Ee81A92091Db6B8B2326B1875ce9388f461",
+        "berachainBepolia": ""
+      }
+    },
+    "publicAllocator": {
+      "name": "Public Allocator",
+      "address": {
+        "berachainMainnet": "0xB62F34Ab315eaDeAc698e8EaEB6Fc2650951BFe7",
+        "berachainBepolia": ""
+      }
+    },
+    "morphoChainlinkOracleV2": {
+      "name": "Morpho Chainlink Oracle V2",
+      "address": {
+        "berachainMainnet": "",
+        "berachainBepolia": ""
+      }
+    },
+    "morphoChainlinkOracleV2Factory": {
+      "name": "Morpho Chainlink Oracle V2 Factory",
+      "address": {
+        "berachainMainnet": "0xAf2FDC54f7bc9d6e8C2D2760E908f4e1beB04d9E",
+        "berachainBepolia": ""
+      }
+    },
+    "urd": {
+      "name": "Universal Reward Distributer (URD)",
+      "address": {
+        "berachainMainnet": "",
+        "berachainBepolia": ""
+      }
+    },
+    "urdFactory": {
+      "name": "Universal Reward Distributer (URD) Factory",
+      "address": {
+        "berachainMainnet": "0x46fE2bc33b661E01A8946BbC3Bf43F2B8382d802",
+        "berachainBepolia": ""
+      }
+    },
+    "vaults": {
+      "re7HoneyVault": {
+        "name": "Re7 Honey Vault",
+        "address": {
+          "berachainMainnet": "0x30BbA9CD9Eb8c95824aa42Faa1Bb397b07545bc1",
+          "berachainBepolia": ""
+        }
+      }
+    },
+    "marketIds": {
+      "wbtcHoney": {
+        "name": "WBTC / HONEY",
+        "id": "0x950962c1cf2591f15806e938bfde9b5f9fbbfcc5fb640030952c08b536f1f167"
+      },
+      "sUSDeHoney": {
+        "name": "sUSDe / HONEY",
+        "id": "0x1ba7904c73d337c39cb88b00180dffb215fc334a6ff47bbe829cd9ee2af00c97"
+      },
+      "wgBERAHoney": {
+        "name": "wgBERA / HONEY",
+        "id": "0x63c2a7c20192095c15d1d668ccce6912999b01ea60eeafcac66eca32015674dd"
+      },
+      "wethHoney": {
+        "name": "WETH / HONEY",
+        "id": "0x1f05d324f604bd1654ec040311d2ac4f5820ecfd1801a3d19d2c6f09d4f7a614"
+      },
+      "wberaHoney": {
+        "name": "WBERA / HONEY",
+        "id": "0x147b032db82d765b9d971eac37c8176260dde0fe91f6a542f20cdd9ede1054df"
+      },
+      "iBERAHoney": {
+        "name": "iBERA / HONEY",
+        "id": "0x594de722a090f8d0df41087c23e2187fb69d9cd6b7b425c6dd56ddc1cff545f0"
+      }
+    }
+  },
+  "stakingPools": {
+    "stakingPoolContractsFactory": {
+      "name": "StakingPoolContractsFactory",
+      "address": {
+        "berachainMainnet": "0xb79b43dBA821Cb67751276Ce050fF4111445fB99",
+        "berachainBepolia": "0x176c081E95C82CA68DEa20CA419C7506Aa063C24"
+      },
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/StakingPoolContractsFactory.json"
+    },
+    "withdrawalVault": {
+      "name": "WithdrawalVault",
+      "address": {
+        "berachainMainnet": "0xE858802Ed532C6DAD2D196AB5B1F2C15F9cb52b4",
+        "berachainBepolia": "0xAFAc2f11Cb39F0521b22494F6101002ce653D2f4"
+      },
+      "abi": "https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/WithdrawalVault.json"
+    }
+  }
+}

--- a/scripts/contracts/generate-pages.mjs
+++ b/scripts/contracts/generate-pages.mjs
@@ -205,7 +205,7 @@ import CoreContractsTable from "/snippets/contracts/generated/core-contracts-tab
 
 This is a list of addresses where you can read from or write to these contracts.
 
-> A full list of Contract ABIs can be found at https://github.com/berachain/doc-abis
+> A full list of Contract ABIs can be found at https://github.com/berachain/abis
 
 <Info>
 Various parties have audited the deployed contracts.

--- a/scripts/contracts/generate-pages.mjs
+++ b/scripts/contracts/generate-pages.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+const contracts = JSON.parse(fs.readFileSync(path.join(repoRoot, "data/contracts.json"), "utf8"));
+const generatedSnippetDir = "snippets/contracts/generated";
+const checkMode = process.argv.includes("--check");
+let changedCount = 0;
+
+function write(relPath, content) {
+  const abs = path.join(repoRoot, relPath);
+  const next = `${content.trimEnd()}\n`;
+  const prev = fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
+  if (prev === next) return;
+
+  changedCount += 1;
+  if (checkMode) {
+    console.log(`Would generate ${relPath}`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, next);
+  console.log(`Generated ${relPath}`);
+}
+
+function berascanLink(address, network) {
+  if (!address) return "N/A";
+  const host = network === "berachainBepolia" ? "https://testnet.berascan.com" : "https://berascan.com";
+  return `[\`${address}\`](${host}/address/${address})`;
+}
+
+function addressFor(item, network) {
+  return item?.address?.[network] ?? "";
+}
+
+function hasAnyDeployment(items, network) {
+  return items.some((item) => Boolean(addressFor(item, network)));
+}
+
+function networkRow(item, network, includeAbi = false, boldName = false) {
+  const address = berascanLink(addressFor(item, network), network);
+  const name = boldName ? `**${item.name}**` : item.name;
+  if (includeAbi) {
+    const abi = item.abi ? `[ABI](${item.abi})` : "N/A";
+    return `| ${name} | ${address} | ${abi} |`;
+  }
+  return `| ${name} | ${address} |`;
+}
+
+function renderAddressCategory(title, items, network) {
+  if (!hasAnyDeployment(items, network)) return "";
+  const rows = items.map((item) => networkRow(item, network)).join("\n");
+  return `### ${title}
+
+| Name | Address |
+|------|---------|
+${rows}`;
+}
+
+function renderAbiCategory(title, items, network, boldName = false) {
+  if (!hasAnyDeployment(items, network)) return "";
+  const rows = items.map((item) => networkRow(item, network, true, boldName)).join("\n");
+  return `### ${title}
+
+| Name | Address | ABI |
+| --- | ------- | --- |
+${rows}`;
+}
+
+function renderGettingStartedSnippet() {
+  const polItems = Object.values(contracts.pol);
+  const tokenItems = Object.values(contracts.tokens);
+  const otherItems = Object.values(contracts.other);
+  const mainSections = [
+    renderAddressCategory("Proof of Liquidity", polItems, "berachainMainnet"),
+    renderAddressCategory("Tokens", tokenItems, "berachainMainnet"),
+    renderAddressCategory("Other", otherItems, "berachainMainnet")
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  const bepSections = [
+    renderAddressCategory("Proof of Liquidity", polItems, "berachainBepolia"),
+    renderAddressCategory("Tokens", tokenItems, "berachainBepolia"),
+    renderAddressCategory("Other", otherItems, "berachainBepolia")
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const nftRows = Object.values(contracts.nfts)
+    .map((item) => `| ${item.name} | \`${item.address.ethereumMainnet}\` | \`${item.address.berachainMainnet}\` |`)
+    .join("\n");
+
+  return `## Mainnet contracts
+
+${mainSections}${bepSections ? `\n\n## Bepolia testnet contracts\n\n${bepSections}` : ""}
+
+### NFT contracts
+
+Berachain NFT contract addresses on both Ethereum (via LayerZero adapters) and Berachain mainnet.
+
+| Collection | Ethereum Adapter | Berachain Address |
+|------------|------------------|-------------------|
+${nftRows}
+`;
+}
+
+function renderBexSnippet() {
+  const items = Object.values(contracts.bex);
+  const mainSection = hasAnyDeployment(items, "berachainMainnet")
+    ? `## Mainnet contracts
+
+| Name | Address | ABI |
+| ---- | ------- | --- |
+${items.map((item) => networkRow(item, "berachainMainnet", true)).join("\n")}`
+    : "";
+  const bepSection = hasAnyDeployment(items, "berachainBepolia")
+    ? `## Bepolia testnet contracts
+
+| Name | Address | ABI |
+| ---- | ------- | --- |
+${items.map((item) => networkRow(item, "berachainBepolia", true)).join("\n")}`
+    : "";
+
+  return [mainSection, bepSection].filter(Boolean).join("\n\n");
+}
+
+function renderBendContractsSnippet() {
+  const bendCore = Object.entries(contracts.bend)
+    .filter(([k]) => !["vaults", "marketIds"].includes(k))
+    .map(([, v]) => v);
+  const vaultItems = Object.values(contracts.bend.vaults);
+
+  function renderBendNetworkSection(label, network) {
+    const parts = [];
+    const morpho = renderAbiCategory("Morpho", bendCore, network, true);
+    if (morpho) parts.push(morpho);
+
+    const vaults = renderAbiCategory("Vaults", vaultItems, network, true);
+    if (vaults) {
+      parts.push(`<Note>
+More vaults may be deployed, please check [https://bend.berachain.com/lend](https://bend.berachain.com/lend) for the latest deployed vaults.
+</Note>
+
+${vaults}`);
+    }
+
+    if (!parts.length) return "";
+    return `## ${label}
+
+${parts.join("\n\n")}`;
+  }
+
+  return [
+    renderBendNetworkSection("Mainnet contracts", "berachainMainnet"),
+    renderBendNetworkSection("Bepolia testnet contracts", "berachainBepolia")
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function renderBendMarketsSnippet() {
+  const rows = Object.values(contracts.bend.marketIds)
+    .map((item) => `| **${item.name}** | \`${item.id}\` |`)
+    .join("\n");
+  return `| Market | ID |
+| --- | --- |
+${rows}
+`;
+}
+
+function renderStakingPoolsSnippet() {
+  const items = Object.values(contracts.stakingPools);
+  const mainSection = hasAnyDeployment(items, "berachainMainnet")
+    ? `#### Mainnet
+
+| Name | Address | ABI |
+|------|---------|-----|
+${items
+  .map((item) => `| **${item.name}** | ${berascanLink(item.address.berachainMainnet, "berachainMainnet")} | [ABI JSON](${item.abi}) |`)
+  .join("\n")}`
+    : "";
+  const bepSection = hasAnyDeployment(items, "berachainBepolia")
+    ? `#### Bepolia
+
+| Name | Address | ABI |
+|------|---------|-----|
+${items
+  .map((item) => `| **${item.name}** | ${berascanLink(item.address.berachainBepolia, "berachainBepolia")} | [ABI JSON](${item.abi}) |`)
+  .join("\n")}`
+    : "";
+
+  return [mainSection, bepSection].filter(Boolean).join("\n\n");
+}
+
+function renderGettingStartedPage() {
+  return `---
+title: "Deployed Contract Addresses"
+description: "Berachain core contract addresses by network."
+---
+
+import CoreContractsTable from "/snippets/contracts/generated/core-contracts-table.mdx";
+
+This is a list of addresses where you can read from or write to these contracts.
+
+> A full list of Contract ABIs can be found at https://github.com/berachain/doc-abis
+
+<Info>
+Various parties have audited the deployed contracts.
+All audit reports are publicly available on [Github](https://github.com/berachain/security-audits).
+</Info>
+
+<CoreContractsTable />
+`;
+}
+
+function renderBexPage() {
+  return `---
+title: "Deployed Contracts"
+description: "Registry of deployed BEX contract addresses by network."
+---
+
+import BexContractsTable from "/snippets/contracts/generated/bex-contracts-table.mdx";
+
+<Warning>
+On January 21st, 2025, Balancer disclosed a long-standing vulnerability in their V2 Vault implementation. BEX incorporates contract logic from Balancer V2 and shares the same vulnerability. Exercise additional caution when creating new pools, particularly when including **untrusted or newly-created tokens**.
+
+**Funds currently deposited in BEX are safe, and no action from LPs is needed.** The issue only potentially affects tokens that are not live on-chain today. Frontend warnings are displayed on BEX for potentially vulnerable tokens.
+
+Future plans include integrating the Balancer V3 codebase, which mitigates this vulnerability and is cross-compatible with current BEX pools.
+
+For more information, see the [Balancer disclosure](https://forum.balancer.fi/t/balancer-v2-token-frontrun-vulnerability-disclosure/6309).
+</Warning>
+
+The following is a list of contract addresses for interacting with Berachain BEX.
+
+<Tip>
+A full list of contract ABIs can be found at [github.com/berachain/doc-abis](https://github.com/berachain/doc-abis).
+</Tip>
+
+<BexContractsTable />
+`;
+}
+
+function renderBendContractsPage() {
+  return `---
+title: "Deployed Contracts"
+description: "Bend smart contract addresses on Berachain; Morpho, IRM, oracles, URD, and related contracts."
+---
+
+import BendContractsTable from "/snippets/contracts/generated/bend-contracts-table.mdx";
+
+Addresses for reading from or writing to Bend contracts. ABIs are in [berachain/doc-abis](https://github.com/berachain/doc-abis).
+
+<Note>
+Deployed contracts have been audited by multiple parties. Reports are on [GitHub](https://github.com/berachain/security-audits).
+</Note>
+
+<BendContractsTable />
+`;
+}
+
+function renderBendMarketsPage() {
+  return `---
+title: "Deployed Markets"
+description: "Market IDs and parameters for deployed Bend lending markets on Berachain."
+---
+
+import BendMarketsTable from "/snippets/contracts/generated/bend-markets-table.mdx";
+
+Market IDs deployed on Bend. For the latest whitelisted markets, see [bend.berachain.com/borrow](https://bend.berachain.com/borrow).
+
+## Market IDs
+
+<BendMarketsTable />
+
+To find a market ID, open [bend.berachain.com/borrow](https://bend.berachain.com/borrow) and read the Market ID from the URL.
+
+<Frame>
+  <img src="/images/bend/deployed-markets-market-id.png" alt="Bend - How to find Market ID" />
+</Frame>
+`;
+}
+
+function renderStakingPoolsPage() {
+  return `---
+title: "Staking Pool Contracts"
+description: "Addresses and ABIs for StakingPoolContractsFactory, WithdrawalVault, and per-pool proxies (StakingPool, SmartOperator, etc.)."
+---
+
+import StakingPoolSingletonsTable from "/snippets/contracts/generated/staking-pools-singletons-table.mdx";
+
+This reference provides contract addresses and links to detailed documentation for each contract in the staking pools system. For an overview of how the contracts work together, see the [Staking Pools Overview](/validators/staking-pools/overview).
+
+## Contract addresses
+
+### Singleton contracts
+
+Singleton contracts are deployed once and shared across all staking pools. The **StakingPoolContractsFactory** is the entry point for deploying a staking pool: you call it to create and register your pool's contracts. The other singletons below are shared infrastructure.
+
+<StakingPoolSingletonsTable />
+
+### Deployed contracts (per pool)
+
+When you deploy a staking pool through the StakingPoolContractsFactory, the factory creates proxy contracts for your validator. These proxy contracts are what you and your stakers interact with directly. Each validator receives unique proxy addresses for these contracts when deploying their staking pool.
+
+The factory returns these proxy addresses when you call \`deployStakingPoolContracts\`. Store these addresses for your operations and provide the StakingPool address to your stakers for deposits.
+
+**Proxy contracts deployed with your pool:**
+
+- **StakingPool**: Main staking functionality and staker interactions. This is the contract address your stakers use to deposit BERA and receive stBERA shares.
+- **SmartOperator**: Validator operations and Proof of Liquidity integration. Use this contract to manage BGT operations, commission rates, reward allocations, and protocol fees.
+- **IncentiveCollector**: Incentive token collection and conversion. Handles the incentive auction mechanism where accumulated tokens can be claimed.
+- **StakingRewardsVault**: Reward collection and automatic reinvestment. Automatically compounds rewards from the consensus layer.
+- **DelegationHandler**: Delegation handling for capital providers. Only deployed if you're using delegated funds from the Berachain Foundation.
+
+For detailed technical documentation of each contract's functions and behavior, see the [Berachain guides repository](https://github.com/berachain/guides/tree/main/apps/staking-pools) and the [install-helpers README](https://github.com/berachain/guides/blob/main/apps/staking-pools/install-helpers/README.md).
+`;
+}
+
+write(`${generatedSnippetDir}/core-contracts-table.mdx`, renderGettingStartedSnippet());
+write(`${generatedSnippetDir}/bex-contracts-table.mdx`, renderBexSnippet());
+write(`${generatedSnippetDir}/bend-contracts-table.mdx`, renderBendContractsSnippet());
+write(`${generatedSnippetDir}/bend-markets-table.mdx`, renderBendMarketsSnippet());
+write(`${generatedSnippetDir}/staking-pools-singletons-table.mdx`, renderStakingPoolsSnippet());
+
+write("build/getting-started/deployed-contracts.mdx", renderGettingStartedPage());
+write("build/bex/deployed-contracts.mdx", renderBexPage());
+write("build/bend/deployed-contracts.mdx", renderBendContractsPage());
+write("build/bend/deployed-markets.mdx", renderBendMarketsPage());
+write("validators/staking-pools/contracts.mdx", renderStakingPoolsPage());
+
+if (checkMode) {
+  if (changedCount > 0) {
+    console.error(
+      `Generated contract docs are stale (${changedCount} file(s) would change). Run node scripts/contracts/generate-pages.mjs and commit the outputs.`
+    );
+    process.exit(1);
+  }
+  console.log("Generated contract docs are up to date.");
+}

--- a/scripts/hooks/install-pre-commit.sh
+++ b/scripts/hooks/install-pre-commit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+
+mkdir -p "$ROOT_DIR/.git/hooks"
+cp "$ROOT_DIR/.githooks/pre-commit" "$ROOT_DIR/.git/hooks/pre-commit"
+chmod +x "$ROOT_DIR/.git/hooks/pre-commit"
+
+echo "Installed pre-commit hook to .git/hooks/pre-commit"

--- a/snippets/contracts/generated/bend-contracts-table.mdx
+++ b/snippets/contracts/generated/bend-contracts-table.mdx
@@ -1,0 +1,28 @@
+## Mainnet contracts
+
+### Morpho
+
+| Name | Address | ABI |
+| --- | ------- | --- |
+| **Morpho (Vault)** | [`0x24147243f9c08d835C218Cda1e135f8dFD0517D0`](https://berascan.com/address/0x24147243f9c08d835C218Cda1e135f8dFD0517D0) | N/A |
+| **Adaptive Curve IRM** | [`0xcf247Df3A2322Dea0D408f011c194906E77a6f62`](https://berascan.com/address/0xcf247Df3A2322Dea0D408f011c194906E77a6f62) | N/A |
+| **Bundler3** | [`0xF920140A65D0f412f2AB3e76C4fEAB5Eef0657ae`](https://berascan.com/address/0xF920140A65D0f412f2AB3e76C4fEAB5Eef0657ae) | N/A |
+| **General Adapter 1** | [`0xd2B9667F5214115E27937C410cAeE83E3a901Df7`](https://berascan.com/address/0xd2B9667F5214115E27937C410cAeE83E3a901Df7) | N/A |
+| **Meta Morpho V1.1** | N/A | N/A |
+| **Meta Morpho Factory V1.1** | [`0x5EDd48C6ACBd565Eeb31702FD9fa9Cbc86fbE616`](https://berascan.com/address/0x5EDd48C6ACBd565Eeb31702FD9fa9Cbc86fbE616) | N/A |
+| **Meta Fee Partitioner** | [`0x80108Ee81A92091Db6B8B2326B1875ce9388f461`](https://berascan.com/address/0x80108Ee81A92091Db6B8B2326B1875ce9388f461) | N/A |
+| **Public Allocator** | [`0xB62F34Ab315eaDeAc698e8EaEB6Fc2650951BFe7`](https://berascan.com/address/0xB62F34Ab315eaDeAc698e8EaEB6Fc2650951BFe7) | N/A |
+| **Morpho Chainlink Oracle V2** | N/A | N/A |
+| **Morpho Chainlink Oracle V2 Factory** | [`0xAf2FDC54f7bc9d6e8C2D2760E908f4e1beB04d9E`](https://berascan.com/address/0xAf2FDC54f7bc9d6e8C2D2760E908f4e1beB04d9E) | N/A |
+| **Universal Reward Distributer (URD)** | N/A | N/A |
+| **Universal Reward Distributer (URD) Factory** | [`0x46fE2bc33b661E01A8946BbC3Bf43F2B8382d802`](https://berascan.com/address/0x46fE2bc33b661E01A8946BbC3Bf43F2B8382d802) | N/A |
+
+<Note>
+More vaults may be deployed, please check [https://bend.berachain.com/lend](https://bend.berachain.com/lend) for the latest deployed vaults.
+</Note>
+
+### Vaults
+
+| Name | Address | ABI |
+| --- | ------- | --- |
+| **Re7 Honey Vault** | [`0x30BbA9CD9Eb8c95824aa42Faa1Bb397b07545bc1`](https://berascan.com/address/0x30BbA9CD9Eb8c95824aa42Faa1Bb397b07545bc1) | N/A |

--- a/snippets/contracts/generated/bend-markets-table.mdx
+++ b/snippets/contracts/generated/bend-markets-table.mdx
@@ -1,0 +1,8 @@
+| Market | ID |
+| --- | --- |
+| **WBTC / HONEY** | `0x950962c1cf2591f15806e938bfde9b5f9fbbfcc5fb640030952c08b536f1f167` |
+| **sUSDe / HONEY** | `0x1ba7904c73d337c39cb88b00180dffb215fc334a6ff47bbe829cd9ee2af00c97` |
+| **wgBERA / HONEY** | `0x63c2a7c20192095c15d1d668ccce6912999b01ea60eeafcac66eca32015674dd` |
+| **WETH / HONEY** | `0x1f05d324f604bd1654ec040311d2ac4f5820ecfd1801a3d19d2c6f09d4f7a614` |
+| **WBERA / HONEY** | `0x147b032db82d765b9d971eac37c8176260dde0fe91f6a542f20cdd9ede1054df` |
+| **iBERA / HONEY** | `0x594de722a090f8d0df41087c23e2187fb69d9cd6b7b425c6dd56ddc1cff545f0` |

--- a/snippets/contracts/generated/bex-contracts-table.mdx
+++ b/snippets/contracts/generated/bex-contracts-table.mdx
@@ -1,0 +1,33 @@
+## Mainnet contracts
+
+| Name | Address | ABI |
+| ---- | ------- | --- |
+| Vault | [`0x4Be03f781C497A489E3cB0287833452cA9B9E80B`](https://berascan.com/address/0x4Be03f781C497A489E3cB0287833452cA9B9E80B) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IVault.abi.json) |
+| ProtocolFeesCollector | [`0xB8Cf46Cf1b1476E707619913a70B2085d26f1707`](https://berascan.com/address/0xB8Cf46Cf1b1476E707619913a70B2085d26f1707) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesCollector.abi.json) |
+| BalancerHelpers | [`0x5083737EC75a728c265BE578C9d0d5333a2c5951`](https://berascan.com/address/0x5083737EC75a728c265BE578C9d0d5333a2c5951) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerHelpers.abi.json) |
+| PoolCreationHelper | [`0x55dccE8165C88aAd4403a15A9cE3A8E244657dD2`](https://berascan.com/address/0x55dccE8165C88aAd4403a15A9cE3A8E244657dD2) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IPoolCreationHelper.abi.json) |
+| ProtocolFeesWithdrawer | [`0x1635F0E1B3e8A6713d03aE155ba79458Ba3240C7`](https://berascan.com/address/0x1635F0E1B3e8A6713d03aE155ba79458Ba3240C7) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesWithdrawer.abi.json) |
+| ComposableStablePoolFactory | [`0xDfA30BDa0375d4763711AB0CC8D91B20bfCC87E1`](https://berascan.com/address/0xDfA30BDa0375d4763711AB0CC8D91B20bfCC87E1) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IComposableStablePoolFactory.abi.json) |
+| BatchRelayerLibrary | [`0xCB4AE3030bA06F7EEE54A7B96AfcA7457f9525cf`](https://berascan.com/address/0xCB4AE3030bA06F7EEE54A7B96AfcA7457f9525cf) | N/A |
+| BatchRelayerQueryLibrary | [`0x4151083172b2CEFB83A33fD7FC9F6cBabb3Fd08d`](https://berascan.com/address/0x4151083172b2CEFB83A33fD7FC9F6cBabb3Fd08d) | N/A |
+| BalancerRelayer | [`0x6044f181aB5E9C05A4ed9Ce295f3B178d2492EE7`](https://berascan.com/address/0x6044f181aB5E9C05A4ed9Ce295f3B178d2492EE7) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerRelayer.abi.json) |
+| WeightedPoolFactory | [`0xa966fA8F2d5B087FFFA499C0C1240589371Af409`](https://berascan.com/address/0xa966fA8F2d5B087FFFA499C0C1240589371Af409) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IWeightedPoolFactory.abi.json) |
+| ProtocolFeePercentagesProvider | [`0x33C88ffdEe710ed3908C791137Bd1D4421AabBBf`](https://berascan.com/address/0x33C88ffdEe710ed3908C791137Bd1D4421AabBBf) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeePercentagesProvider.abi.json) |
+| BalancerQueries | [`0x3C612e132624f4Bd500eE1495F54565F0bcc9b59`](https://berascan.com/address/0x3C612e132624f4Bd500eE1495F54565F0bcc9b59) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerQueries.abi.json) |
+
+## Bepolia testnet contracts
+
+| Name | Address | ABI |
+| ---- | ------- | --- |
+| Vault | [`0x708cA656b68A6b7384a488A36aD33505a77241FE`](https://testnet.berascan.com/address/0x708cA656b68A6b7384a488A36aD33505a77241FE) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IVault.abi.json) |
+| ProtocolFeesCollector | [`0x05A607aCf3548E84DD1E44c3706F850c849058Da`](https://testnet.berascan.com/address/0x05A607aCf3548E84DD1E44c3706F850c849058Da) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesCollector.abi.json) |
+| BalancerHelpers | [`0xC7c981ADcDC5d48fed0CD52807fb2bAB22676C8f`](https://testnet.berascan.com/address/0xC7c981ADcDC5d48fed0CD52807fb2bAB22676C8f) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerHelpers.abi.json) |
+| PoolCreationHelper | [`0x0dC9964F6CA33d9EF38DEB4925234766127C6B36`](https://testnet.berascan.com/address/0x0dC9964F6CA33d9EF38DEB4925234766127C6B36) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IPoolCreationHelper.abi.json) |
+| ProtocolFeesWithdrawer | [`0x8c2D77f0CfcD4Af9cF41494EfE500FE324012c06`](https://testnet.berascan.com/address/0x8c2D77f0CfcD4Af9cF41494EfE500FE324012c06) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeesWithdrawer.abi.json) |
+| ComposableStablePoolFactory | [`0xB60DbBaCEaeC23486a64d12089F467ef949f1bb1`](https://testnet.berascan.com/address/0xB60DbBaCEaeC23486a64d12089F467ef949f1bb1) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IComposableStablePoolFactory.abi.json) |
+| BatchRelayerLibrary | [`0xfD772657FC8c4Ed3884AfF151b680883814052FA`](https://testnet.berascan.com/address/0xfD772657FC8c4Ed3884AfF151b680883814052FA) | N/A |
+| BatchRelayerQueryLibrary | [`0x263a1C5B2c5851beA2177eb8D6caefdfF2A25601`](https://testnet.berascan.com/address/0x263a1C5B2c5851beA2177eb8D6caefdfF2A25601) | N/A |
+| BalancerRelayer | [`0x343215E156Ff586711a5B8C49Fe3099BAF22624C`](https://testnet.berascan.com/address/0x343215E156Ff586711a5B8C49Fe3099BAF22624C) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerRelayer.abi.json) |
+| WeightedPoolFactory | [`0xf1d23276C7b271B2aC595C78977b2312E9954D57`](https://testnet.berascan.com/address/0xf1d23276C7b271B2aC595C78977b2312E9954D57) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IWeightedPoolFactory.abi.json) |
+| ProtocolFeePercentagesProvider | [`0x8119E412E00fe3c857739E95dB147817Bf615dB8`](https://testnet.berascan.com/address/0x8119E412E00fe3c857739E95dB147817Bf615dB8) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IProtocolFeePercentagesProvider.abi.json) |
+| BalancerQueries | [`0xE3723383a0EA73D5c0dE424BAA97F97f86f6cF92`](https://testnet.berascan.com/address/0xE3723383a0EA73D5c0dE424BAA97F97f86f6cF92) | [ABI](https://github.com/berachain/doc-abis/blob/main/bex/IBalancerQueries.abi.json) |

--- a/snippets/contracts/generated/core-contracts-table.mdx
+++ b/snippets/contracts/generated/core-contracts-table.mdx
@@ -1,0 +1,78 @@
+## Mainnet contracts
+
+### Proof of Liquidity
+
+| Name | Address |
+|------|---------|
+| BGT Token | [`0x656b95E550C07a9ffe548bd4085c72418Ceb1dba`](https://berascan.com/address/0x656b95E550C07a9ffe548bd4085c72418Ceb1dba) |
+| BeraChef | [`0xdf960E8F3F19C481dDE769edEDD439ea1a63426a`](https://berascan.com/address/0xdf960E8F3F19C481dDE769edEDD439ea1a63426a) |
+| BlockRewardController | [`0x2B6e40f65D82A0cB98795bC7587a71bfa49fBB2B`](https://berascan.com/address/0x2B6e40f65D82A0cB98795bC7587a71bfa49fBB2B) |
+| Distributor | [`0x1b4854DE16279B3d6b37b0a28Abe36A53374A1Cd`](https://berascan.com/address/0x1b4854DE16279B3d6b37b0a28Abe36A53374A1Cd) |
+| FeeCollector | [`0xD435F3e35EEd75C1c21952B8Bc45D0159a2593C9`](https://berascan.com/address/0xD435F3e35EEd75C1c21952B8Bc45D0159a2593C9) |
+| RewardVaultFactory | [`0x94Ad6Ac84f6C6FbA8b8CCbD71d9f4f101def52a8`](https://berascan.com/address/0x94Ad6Ac84f6C6FbA8b8CCbD71d9f4f101def52a8) |
+| BGTStaker | [`0x791fb02A77Ca787EFf6d5e7e83691f76DB55F96F`](https://berascan.com/address/0x791fb02A77Ca787EFf6d5e7e83691f76DB55F96F) |
+| Governance | [`0x24a4B37F9c40fB0E80ec436Df2e9989FBAFa8bB7`](https://berascan.com/address/0x24a4B37F9c40fB0E80ec436Df2e9989FBAFa8bB7) |
+| Timelock | [`0x50bfF7b88f97c1cB37d6CfCB518A20b306Aa7355`](https://berascan.com/address/0x50bfF7b88f97c1cB37d6CfCB518A20b306Aa7355) |
+
+### Tokens
+
+| Name | Address |
+|------|---------|
+| WBERA | [`0x6969696969696969696969696969696969696969`](https://berascan.com/address/0x6969696969696969696969696969696969696969) |
+| HONEY | [`0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce`](https://berascan.com/address/0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce) |
+| HoneyFactory | [`0xA81F0019d442f19f66880bcf2698B4E5D5Ec249A`](https://berascan.com/address/0xA81F0019d442f19f66880bcf2698B4E5D5Ec249A) |
+
+### Other
+
+| Name | Address |
+|------|---------|
+| BeaconDeposit | [`0x4242424242424242424242424242424242424242`](https://berascan.com/address/0x4242424242424242424242424242424242424242) |
+| Create2 | [`0x4e59b44847b379578588920cA78FbF26c0B4956C`](https://berascan.com/address/0x4e59b44847b379578588920cA78FbF26c0B4956C) |
+| Multicall3 | [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://berascan.com/address/0xcA11bde05977b3631167028862bE2a173976CA11) |
+| Permit2 | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://berascan.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
+
+## Bepolia testnet contracts
+
+### Proof of Liquidity
+
+| Name | Address |
+|------|---------|
+| BGT Token | [`0x656b95E550C07a9ffe548bd4085c72418Ceb1dba`](https://testnet.berascan.com/address/0x656b95E550C07a9ffe548bd4085c72418Ceb1dba) |
+| BeraChef | [`0xdf960E8F3F19C481dDE769edEDD439ea1a63426a`](https://testnet.berascan.com/address/0xdf960E8F3F19C481dDE769edEDD439ea1a63426a) |
+| BlockRewardController | [`0x1AE7dD7AE06F6C58B4524d9c1f816094B1bcCD8e`](https://testnet.berascan.com/address/0x1AE7dD7AE06F6C58B4524d9c1f816094B1bcCD8e) |
+| Distributor | [`0xD2f19a79b026Fb636A7c300bF5947df113940761`](https://testnet.berascan.com/address/0xD2f19a79b026Fb636A7c300bF5947df113940761) |
+| FeeCollector | [`0x7bb8DdaC7FbE3FFC0f4B3c73C4F158B06CF82650`](https://testnet.berascan.com/address/0x7bb8DdaC7FbE3FFC0f4B3c73C4F158B06CF82650) |
+| RewardVaultFactory | [`0x94Ad6Ac84f6C6FbA8b8CCbD71d9f4f101def52a8`](https://testnet.berascan.com/address/0x94Ad6Ac84f6C6FbA8b8CCbD71d9f4f101def52a8) |
+| BGTStaker | [`0x44F07Ce5AfeCbCC406e6beFD40cc2998eEb8c7C6`](https://testnet.berascan.com/address/0x44F07Ce5AfeCbCC406e6beFD40cc2998eEb8c7C6) |
+| Governance | [`0x4f4A5c2194B8e856b7a05B348F6ba3978FB6f6D5`](https://testnet.berascan.com/address/0x4f4A5c2194B8e856b7a05B348F6ba3978FB6f6D5) |
+| Timelock | [`0xb5f2000b5744f207c931526cAE2134cAa8b6862a`](https://testnet.berascan.com/address/0xb5f2000b5744f207c931526cAE2134cAa8b6862a) |
+
+### Tokens
+
+| Name | Address |
+|------|---------|
+| WBERA | [`0x6969696969696969696969696969696969696969`](https://testnet.berascan.com/address/0x6969696969696969696969696969696969696969) |
+| HONEY | [`0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce`](https://testnet.berascan.com/address/0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce) |
+| HoneyFactory | [`0xA4aFef880F5cE1f63c9fb48F661E27F8B4216401`](https://testnet.berascan.com/address/0xA4aFef880F5cE1f63c9fb48F661E27F8B4216401) |
+
+### Other
+
+| Name | Address |
+|------|---------|
+| BeaconDeposit | [`0x4242424242424242424242424242424242424242`](https://testnet.berascan.com/address/0x4242424242424242424242424242424242424242) |
+| Create2 | [`0x4e59b44847b379578588920cA78FbF26c0B4956C`](https://testnet.berascan.com/address/0x4e59b44847b379578588920cA78FbF26c0B4956C) |
+| Multicall3 | [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://testnet.berascan.com/address/0xcA11bde05977b3631167028862bE2a173976CA11) |
+| Permit2 | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://testnet.berascan.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) |
+
+### NFT contracts
+
+Berachain NFT contract addresses on both Ethereum (via LayerZero adapters) and Berachain mainnet.
+
+| Collection | Ethereum Adapter | Berachain Address |
+|------------|------------------|-------------------|
+| Bong Bears | `0x1897C001341F81Ca72154b75b882aE708e06bF48` | `0x141De07E5D4C4759EC9301DA106115D4841f66cD` |
+| Bond Bears | `0x6b1C374105467d1fC1090C989BcbbCC172c8a89c` | `0xA0CF472E6132F6B822a944f6F31aA7b261c7c375` |
+| Boo Bears | `0x7591992F1a98636C6B7207f30382ca4Bec83D9Be` | `0xf49ec5db255854C4a567de5AB3826c9AAbaFc7cF` |
+| Baby Bears | `0xc48C54e92d135B356DD0CbF50F803A8c8d38968b` | `0xDDeAf391c4be2d01ca52aBb8C159a06820ef078C` |
+| Band Bears | `0x392Faa1b0EF108ded69897Ba5382E909C39Fc09e` | `0x7711B2Eb2451259dbF211e30157ceB7CFeb79a19` |
+| Bit Bears | `0x3EB12398753eEd7E8747321c37C85De30d8E2e94` | `0x72D876D9cdf4001b836f8E47254d0551EdA2eebB` |

--- a/snippets/contracts/generated/staking-pools-singletons-table.mdx
+++ b/snippets/contracts/generated/staking-pools-singletons-table.mdx
@@ -1,0 +1,13 @@
+#### Mainnet
+
+| Name | Address | ABI |
+|------|---------|-----|
+| **StakingPoolContractsFactory** | [`0xb79b43dBA821Cb67751276Ce050fF4111445fB99`](https://berascan.com/address/0xb79b43dBA821Cb67751276Ce050fF4111445fB99) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/StakingPoolContractsFactory.json) |
+| **WithdrawalVault** | [`0xE858802Ed532C6DAD2D196AB5B1F2C15F9cb52b4`](https://berascan.com/address/0xE858802Ed532C6DAD2D196AB5B1F2C15F9cb52b4) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/WithdrawalVault.json) |
+
+#### Bepolia
+
+| Name | Address | ABI |
+|------|---------|-----|
+| **StakingPoolContractsFactory** | [`0x176c081E95C82CA68DEa20CA419C7506Aa063C24`](https://testnet.berascan.com/address/0x176c081E95C82CA68DEa20CA419C7506Aa063C24) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/StakingPoolContractsFactory.json) |
+| **WithdrawalVault** | [`0xAFAc2f11Cb39F0521b22494F6101002ce653D2f4`](https://testnet.berascan.com/address/0xAFAc2f11Cb39F0521b22494F6101002ce653D2f4) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/WithdrawalVault.json) |

--- a/validators/operations/self-hosted-rpc.mdx
+++ b/validators/operations/self-hosted-rpc.mdx
@@ -9,9 +9,9 @@ Berachain operates public RPCs at https://rpc.berachain.com/. These serve normal
 
 ## Using RPC efficiently
 
-You can transmit queries through two common transports. The most common is JSON-RPC over HTTP or HTTPS. Well-behaved clients typically reuse connections with keep-alive enabled, but high request rates still pay per-request overhead from headers, request and response framing, and retry behaviour. That overhead can amplify tail latency.
+You can transmit queries through two common transports. The most common is JSON-RPC over HTTP or HTTPS. Well-behaved clients typically reuse connections with keep-alive enabled, but high request rates still pay per-request overhead from headers, request and response framing, and retry behavior. That overhead can amplify tail latency.
 
-Retry discipline matters at least as much as raw request volume. If you are seeing `429` rate limits or intermittent timeouts, avoid "retry immediately" loops: they create retry storms that make throttling worse and can turn partial degradation into a full outage. Use exponential backoff with jitter, honour `Retry-After` when present, and cap retries. When upstreams stay unhealthy, shed load by queueing work, degrading non-critical reads, or failing fast. Be especially careful retrying write flows; reads are typically safe to retry, but duplicate submissions can surprise you.
+Retry discipline matters at least as much as raw request volume. If you are seeing `429` rate limits or intermittent timeouts, avoid "retry immediately" loops: they create retry storms that make throttling worse and can turn partial degradation into a full outage. Use exponential backoff with jitter, honor `Retry-After` when present, and cap retries. When upstreams stay unhealthy, shed load by queueing work, degrading non-critical reads, or failing fast. Be especially careful retrying write flows; reads are typically safe to retry, but duplicate submissions can surprise you.
 
 If you need streaming updates or you are polling aggressively, [WebSockets](https://ethereum.org/developers/tutorials/using-websockets/) are often a better fit. WebSocket connections are long-lived, which makes push workflows viable and reduces churn from repeated connect/reconnect cycles.
 

--- a/validators/staking-pools/contracts.mdx
+++ b/validators/staking-pools/contracts.mdx
@@ -3,6 +3,8 @@ title: "Staking Pool Contracts"
 description: "Addresses and ABIs for StakingPoolContractsFactory, WithdrawalVault, and per-pool proxies (StakingPool, SmartOperator, etc.)."
 ---
 
+import StakingPoolSingletonsTable from "/snippets/contracts/generated/staking-pools-singletons-table.mdx";
+
 This reference provides contract addresses and links to detailed documentation for each contract in the staking pools system. For an overview of how the contracts work together, see the [Staking Pools Overview](/validators/staking-pools/overview).
 
 ## Contract addresses
@@ -11,19 +13,7 @@ This reference provides contract addresses and links to detailed documentation f
 
 Singleton contracts are deployed once and shared across all staking pools. The **StakingPoolContractsFactory** is the entry point for deploying a staking pool: you call it to create and register your pool's contracts. The other singletons below are shared infrastructure.
 
-#### Mainnet
-
-| Name | Address | ABI |
-|------|---------|-----|
-| **StakingPoolContractsFactory** | [`0xb79b43dBA821Cb67751276Ce050fF4111445fB99`](https://berascan.com/address/0xb79b43dBA821Cb67751276Ce050fF4111445fB99) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/StakingPoolContractsFactory.json) |
-| **WithdrawalVault** | [`0xE858802Ed532C6DAD2D196AB5B1F2C15F9cb52b4`](https://berascan.com/address/0xE858802Ed532C6DAD2D196AB5B1F2C15F9cb52b4) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/WithdrawalVault.json) |
-
-#### Bepolia
-
-| Name | Address | ABI |
-|------|---------|-----|
-| **StakingPoolContractsFactory** | [`0x176c081E95C82CA68DEa20CA419C7506Aa063C24`](https://testnet.berascan.com/address/0x176c081E95C82CA68DEa20CA419C7506Aa063C24) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/StakingPoolContractsFactory.json) |
-| **WithdrawalVault** | [`0xAFAc2f11Cb39F0521b22494F6101002ce653D2f4`](https://testnet.berascan.com/address/0xAFAc2f11Cb39F0521b22494F6101002ce653D2f4) | [ABI JSON](https://github.com/berachain/abis/blob/main/mainnet/contracts-staking-pools/WithdrawalVault.json) |
+<StakingPoolSingletonsTable />
 
 ### Deployed contracts (per pool)
 


### PR DESCRIPTION
This PR reintroduces a single source of truth for contract addresses and makes deployed-contract docs generated output instead of hand-maintained tables. It also tightens the workflow so stale generated files are caught before commit.

- add data/contracts.json as canonical contract data source and generate contract snippets/pages from it
- move generated snippet outputs under snippets/contracts/generated/ and update deployed-contract pages to import from generated snippets
- backfill data/contracts.json from old constants.json
- render network sections conditionally so empty networks do not emit headings/tables
- add a generator with a `--check` mode to contracts generator so stale outputs fail with non-zero exit
- add repo pre-commit hook + installer to run generator check
- document generation/check-in expectations in CONTRIBUTING.md
