### PR TITLE
add old docs redirects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -378,6 +378,15 @@
     { "source": "/vi/validators/staking-pools/installation", "destination": "/validators/staking-pools/installation" },
     { "source": "/vi/validators/staking-pools/operators", "destination": "/validators/staking-pools/operators" },
     { "source": "/vi/validators/staking-pools/delegators", "destination": "/validators/staking-pools/delegators" },
-    { "source": "/vi/validators/staking-pools/contracts", "destination": "/validators/staking-pools/contracts" }
+    { "source": "/vi/validators/staking-pools/contracts", "destination": "/validators/staking-pools/contracts" },
+    { "source": "/nodes/quickstart", "destination": "/validators/operations/quickstart" },
+    { "source": "/nodes/monitoring", "destination": "/validators/operations/monitoring" },
+    { "source": "/nodes/production-checklist", "destination": "/validators/operations/production-checklist" },
+    { "source": "/nodes/self-hosted-rpc", "destination": "/validators/operations/self-hosted-rpc" },
+    { "source": "/nodes/staking-pools/contracts/:slug*", "destination": "/validators/staking-pools/contracts" },
+    { "source": "/beacon-kit/api", "destination": "/validators/beaconkit/overview" },
+    { "source": "/beacon-kit/cli", "destination": "/validators/beaconkit/overview" },
+    { "source": "/beacon-kit/configuration", "destination": "/validators/beaconkit/overview" },
+    { "source": "/beacon-kit/what-is-beaconkit", "destination": "/validators/beaconkit/overview" }
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -379,14 +379,14 @@
     { "source": "/vi/validators/staking-pools/operators", "destination": "/validators/staking-pools/operators" },
     { "source": "/vi/validators/staking-pools/delegators", "destination": "/validators/staking-pools/delegators" },
     { "source": "/vi/validators/staking-pools/contracts", "destination": "/validators/staking-pools/contracts" },
-    { "source": "/nodes/quickstart", "destination": "/validators/operations/quickstart" },
-    { "source": "/nodes/monitoring", "destination": "/validators/operations/monitoring" },
-    { "source": "/nodes/production-checklist", "destination": "/validators/operations/production-checklist" },
-    { "source": "/nodes/self-hosted-rpc", "destination": "/validators/operations/self-hosted-rpc" },
-    { "source": "/nodes/staking-pools/contracts/:slug*", "destination": "/validators/staking-pools/contracts" },
-    { "source": "/beacon-kit/api", "destination": "/validators/beaconkit/overview" },
-    { "source": "/beacon-kit/cli", "destination": "/validators/beaconkit/overview" },
-    { "source": "/beacon-kit/configuration", "destination": "/validators/beaconkit/overview" },
-    { "source": "/beacon-kit/what-is-beaconkit", "destination": "/validators/beaconkit/overview" }
+    { "source": "/nodes/quickstart", "destination": "/validators/operations/quickstart", "permanent": true },
+    { "source": "/nodes/monitoring", "destination": "/validators/operations/monitoring", "permanent": true },
+    { "source": "/nodes/production-checklist", "destination": "/validators/operations/production-checklist", "permanent": true },
+    { "source": "/nodes/self-hosted-rpc", "destination": "/validators/operations/self-hosted-rpc", "permanent": true },
+    { "source": "/nodes/staking-pools/contracts/:slug*", "destination": "/validators/staking-pools/contracts", "permanent": true },
+    { "source": "/beacon-kit/api", "destination": "/validators/beaconkit/overview", "permanent": true },
+    { "source": "/beacon-kit/cli", "destination": "/validators/beaconkit/overview", "permanent": true },
+    { "source": "/beacon-kit/configuration", "destination": "/validators/beaconkit/overview", "permanent": true },
+    { "source": "/beacon-kit/what-is-beaconkit", "destination": "/validators/beaconkit/overview", "permanent": true }
   ]
 }


### PR DESCRIPTION
Redirect old main-docs URLs to current Mintlify paths so bookmarks and links keep working.

**Redirects added (ported content only):**
- `/nodes/quickstart`, `/nodes/monitoring`, `/nodes/production-checklist`, `/nodes/self-hosted-rpc` → `/validators/operations/*`
- `/nodes/staking-pools/contracts/:slug*` → `/validators/staking-pools/contracts` (single contracts page)
- `/beacon-kit/api`, `/beacon-kit/cli`, `/beacon-kit/configuration`, `/beacon-kit/what-is-beaconkit` → `/validators/beaconkit/overview`

Ported-content only; no broad wildcards. No locale redirects. All use `permanent: true` (301/308). Verified locally with mintlify dev + curl.