### PR TITLE
Fix broken /validators/ redirects and add redirect checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,36 @@
-.PHONY: help dev validate broken-links a11y check contracts-generate mint-install broken-assets
+.PHONY: help dev check check-validate check-links check-assets check-a11y check-redirects contracts-generate mint-install
 
 help:
 	@echo "Common docs tasks:"
 	@echo "  make dev                # Run local Mintlify server (http://localhost:3000)"
-	@echo "  make validate           # Validate docs build"
-	@echo "  make broken-links       # Check for broken links"
-	@echo "  make broken-assets      # Check /assets for orphaned + missing refs"
-	@echo "  make a11y               # Run accessibility checks"
-	@echo "  make check              # Run validate + broken-links + a11y"
+	@echo "  make check              # Run all checks (validate, links, assets, a11y, redirects)"
+	@echo "  make check-validate     # Validate docs build"
+	@echo "  make check-links        # Check for broken links"
+	@echo "  make check-assets       # Check /images for orphaned + missing refs"
+	@echo "  make check-a11y         # Run accessibility checks"
+	@echo "  make check-redirects    # Verify all redirects land on HTTP 200 (needs running server)"
+	@echo "                          # Override port: BASE_URL=http://localhost:3335 make check-redirects"
 	@echo "  make contracts-generate # Regenerate contract pages/snippets from data/contracts.json"
 	@echo "  make mint-install       # Install Mintlify CLI globally via npm"
 
 dev:
 	mint dev
 
-validate:
+check: check-validate check-links check-assets check-a11y check-redirects
+
+check-validate:
 	mint validate
 
-broken-links:
+check-links:
 	mint broken-links
 
-a11y:
+check-a11y:
 	mint a11y
 
-check: validate broken-links a11y
+check-redirects:
+	bash scripts/check-redirects.sh $${BASE_URL:-http://localhost:3000}
 
-contracts-generate:
-	node scripts/contracts/generate-pages.mjs
-
-mint-install:
-	npm i -g mint
-
-broken-assets:
+check-assets:
 	@assets_file_list="$$(mktemp)"; \
 	assets_ref_list="$$(mktemp)"; \
 	rg --files images | sed 's#^images#/images#' | sort -u > "$$assets_file_list"; \
@@ -53,3 +52,9 @@ broken-assets:
 		exit 1; \
 	fi; \
 	echo "✅ No orphaned or missing asset references found."
+
+contracts-generate:
+	node scripts/contracts/generate-pages.mjs
+
+mint-install:
+	npm i -g mint

--- a/docs.json
+++ b/docs.json
@@ -401,19 +401,19 @@
     },
     {
       "source": "/build/beaconkit/overview",
-      "destination": "/validators/beaconkit/overview"
+      "destination": "/nodes/beaconkit/overview"
     },
     {
       "source": "/cn/validators/beaconkit/overview",
-      "destination": "/validators/beaconkit/overview"
+      "destination": "/nodes/beaconkit/overview"
     },
     {
       "source": "/ko/validators/beaconkit/overview",
-      "destination": "/validators/beaconkit/overview"
+      "destination": "/nodes/beaconkit/overview"
     },
     {
       "source": "/vi/validators/beaconkit/overview",
-      "destination": "/validators/beaconkit/overview"
+      "destination": "/nodes/beaconkit/overview"
     },
     {
       "source": "/cn/validators/operations/self-hosted-rpc",
@@ -488,48 +488,53 @@
       "destination": "/validators/staking-pools/contracts"
     },
     {
+      "source": "/validators/:slug*",
+      "destination": "/nodes/:slug*",
+      "permanent": true
+    },
+    {
       "source": "/nodes/quickstart",
-      "destination": "/validators/operations/quickstart",
+      "destination": "/nodes/operations/quickstart",
       "permanent": true
     },
     {
       "source": "/nodes/monitoring",
-      "destination": "/validators/operations/monitoring",
+      "destination": "/nodes/operations/monitoring",
       "permanent": true
     },
     {
       "source": "/nodes/production-checklist",
-      "destination": "/validators/operations/production-checklist",
+      "destination": "/nodes/operations/production-checklist",
       "permanent": true
     },
     {
       "source": "/nodes/self-hosted-rpc",
-      "destination": "/validators/operations/self-hosted-rpc",
+      "destination": "/nodes/operations/self-hosted-rpc",
       "permanent": true
     },
     {
       "source": "/nodes/staking-pools/contracts/:slug*",
-      "destination": "/validators/staking-pools/contracts",
+      "destination": "/nodes/staking-pools/contracts",
       "permanent": true
     },
     {
       "source": "/beacon-kit/api",
-      "destination": "/validators/beaconkit/overview",
+      "destination": "/nodes/beaconkit/overview",
       "permanent": true
     },
     {
       "source": "/beacon-kit/cli",
-      "destination": "/validators/beaconkit/overview",
+      "destination": "/nodes/beaconkit/overview",
       "permanent": true
     },
     {
       "source": "/beacon-kit/configuration",
-      "destination": "/validators/beaconkit/overview",
+      "destination": "/nodes/beaconkit/overview",
       "permanent": true
     },
     {
       "source": "/beacon-kit/what-is-beaconkit",
-      "destination": "/validators/beaconkit/overview",
+      "destination": "/nodes/beaconkit/overview",
       "permanent": true
     },
     {
@@ -544,7 +549,7 @@
     },
     {
       "source": "/learn/what-is-beaconkit",
-      "destination": "/validators/beaconkit/overview",
+      "destination": "/nodes/beaconkit/overview",
       "permanent": true
     },
     {
@@ -644,7 +649,7 @@
     },
     {
       "source": "/learn/guides/boost-a-validator",
-      "destination": "/validators/guides/become-a-validator",
+      "destination": "/nodes/guides/become-a-validator",
       "permanent": true
     },
     {
@@ -744,12 +749,12 @@
     },
     {
       "source": "/developers/hub-api",
-      "destination": "/build/apis/hub-api",
+      "destination": "/build/getting-started/developer-tools",
       "permanent": true
     },
     {
       "source": "/developers/claim-api",
-      "destination": "/build/apis/claim-api",
+      "destination": "/build/getting-started/developer-tools",
       "permanent": true
     },
     {
@@ -949,92 +954,67 @@
     },
     {
       "source": "/nodes",
-      "destination": "/validators/overview/index",
+      "destination": "/nodes/overview/index",
       "permanent": true
     },
     {
       "source": "/nodes/validator-lifecycle",
-      "destination": "/validators/architecture/validator-lifecycle",
+      "destination": "/nodes/architecture/validator-lifecycle",
       "permanent": true
     },
     {
       "source": "/nodes/beaconkit-consensus",
-      "destination": "/validators/architecture/beaconkit-consensus",
+      "destination": "/nodes/architecture/beaconkit-consensus",
       "permanent": true
     },
     {
       "source": "/nodes/evm-execution",
-      "destination": "/validators/architecture/evm-execution",
+      "destination": "/nodes/architecture/evm-execution",
       "permanent": true
     },
     {
       "source": "/nodes/faq",
-      "destination": "/validators/help/faq",
+      "destination": "/nodes/help/faq",
       "permanent": true
     },
     {
       "source": "/nodes/guides/validator",
-      "destination": "/validators/guides/become-a-validator",
+      "destination": "/nodes/guides/become-a-validator",
       "permanent": true
     },
     {
       "source": "/nodes/guides/operator-address",
-      "destination": "/validators/guides/change-operator-address",
+      "destination": "/nodes/guides/change-operator-address",
       "permanent": true
     },
     {
       "source": "/nodes/guides/reward-allocation",
-      "destination": "/validators/guides/manage-reward-allocations",
+      "destination": "/nodes/guides/manage-reward-allocations",
       "permanent": true
     },
     {
       "source": "/nodes/guides/increase-validator-bera-stake",
-      "destination": "/validators/guides/increase-validator-stake",
-      "permanent": true
-    },
-    {
-      "source": "/nodes/guides/withdraw-stake",
-      "destination": "/validators/guides/withdraw-stake",
+      "destination": "/nodes/guides/increase-validator-stake",
       "permanent": true
     },
     {
       "source": "/nodes/guides/docker-devnet",
-      "destination": "/validators/guides/local-devnet-docker",
+      "destination": "/nodes/guides/local-devnet-docker",
       "permanent": true
     },
     {
       "source": "/nodes/guides/kurtosis",
-      "destination": "/validators/guides/local-devnet-kurtosis",
-      "permanent": true
-    },
-    {
-      "source": "/nodes/guides/manage-incentives-commission",
-      "destination": "/validators/guides/manage-incentives-commission",
+      "destination": "/nodes/guides/local-devnet-kurtosis",
       "permanent": true
     },
     {
       "source": "/nodes/staking-pools",
-      "destination": "/validators/staking-pools/overview",
-      "permanent": true
-    },
-    {
-      "source": "/nodes/staking-pools/installation",
-      "destination": "/validators/staking-pools/installation",
-      "permanent": true
-    },
-    {
-      "source": "/nodes/staking-pools/operators",
-      "destination": "/validators/staking-pools/operators",
-      "permanent": true
-    },
-    {
-      "source": "/nodes/staking-pools/delegators",
-      "destination": "/validators/staking-pools/delegators",
+      "destination": "/nodes/staking-pools/overview",
       "permanent": true
     },
     {
       "source": "/nodes/self-hosted",
-      "destination": "/validators/operations/self-hosted-rpc",
+      "destination": "/nodes/operations/self-hosted-rpc",
       "permanent": true
     },
     {

--- a/general/tokens/bera.mdx
+++ b/general/tokens/bera.mdx
@@ -13,7 +13,7 @@ The BERA token serves two main purposes on the Berachain network:
 
 BERA is used to pay for transactions on the Berachain network (hence its designation as the "gas token"). Tokens used for transaction fees are burned, removing them from the circulating supply. [Check out the hundreds of projects and dapps in the Berachain Ecosystem](https://ecosystem.berachain.com/).
 
-### Staking BERA {#staking-bera}
+### Staking BERA
 
 BERA can be staked a number of ways:
 
@@ -26,7 +26,7 @@ Validators stake BERA to operate a validator. Within the active set, the more BE
 
 To learn more about how BERA staking affects block production and emissions, see [Block Rewards](/general/proof-of-liquidity/block-rewards).
 
-## Tokenomics {#tokenomics}
+## Tokenomics
 
 BGT governs emissions and economic incentives. The following documents the fixed supply, allocation, and release schedule for BERA.
 

--- a/scripts/check-redirects.sh
+++ b/scripts/check-redirects.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:3000}"
+DOCS_JSON="$(cd "$(dirname "$0")/.." && pwd)/docs.json"
+
+if ! command -v jq &>/dev/null; then
+  echo "jq is required. Install with: brew install jq" >&2
+  exit 1
+fi
+
+if ! curl -s -o /dev/null --max-time 3 "$BASE_URL" 2>/dev/null; then
+  echo "Cannot reach $BASE_URL — start the dev server first (make dev) or pass a reachable URL." >&2
+  exit 1
+fi
+
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
+jq -r '.redirects[] | [.source, .destination] | @tsv' "$DOCS_JSON" > "$tmpfile"
+
+total=$(wc -l < "$tmpfile" | tr -d ' ')
+failed=0
+ok=0
+warned=0
+skipped=0
+
+while IFS=$'\t' read -r source destination; do
+  if echo "$source" | grep -qE ':\w+\*'; then
+    printf "SKIP  %-60s (wildcard)\n" "$source"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  url="${BASE_URL}${source}"
+
+  # -L follows redirects; -w gives final code + number of redirects
+  read -r code hops <<< "$(curl -s -o /dev/null -L --max-redirs 10 --max-time 15 -w '%{http_code} %{num_redirects}' "$url")"
+
+  if [ "$code" = "200" ] && [ "$hops" -le 1 ]; then
+    printf "OK    %-60s -> %s\n" "$source" "$destination"
+    ok=$((ok + 1))
+  elif [ "$code" = "200" ] && [ "$hops" -gt 1 ]; then
+    printf "WARN  %-60s -> %s  (%s hops)\n" "$source" "$destination" "$hops"
+    warned=$((warned + 1))
+  else
+    printf "FAIL  %-60s -> %s  (HTTP %s after %s hops)\n" "$source" "$destination" "$code" "$hops"
+    failed=$((failed + 1))
+  fi
+done < "$tmpfile"
+
+echo ""
+echo "Results: $total total, $ok ok, $warned warned, $failed failed, $skipped skipped"
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
Redirects from /nodes/* were bouncing through dead /validators/* URLs. Replace 25 individual /validators/* → /nodes/* redirects with a single wildcard, fix all /nodes/* destinations to point directly to the new layout, and fix stale destinations on beacon-kit/learn/build paths.

Also: fix bera.mdx parse error from unsupported {#id} heading syntax, redirect removed API pages to developer-tools, add check-redirects Makefile target, and rename check targets with check- prefix.

