### PR TITLE
docs: add RouteMesh to RPC providers

### DIFF
--- a/build/getting-started/developer-tools.mdx
+++ b/build/getting-started/developer-tools.mdx
@@ -36,6 +36,7 @@ Since Berachain is EVM-compatible, if you're familiar with creating dApps on oth
 - [Nirvana](https://nirvanalabs.io/nodes/berachain)
 - [QuickNode RPC](https://quicknode.notion.site/QuickNode-Benefits-for-Berachain-Developers-175d54ec5d644f598fde797633add2c1?pvs=4)
 - [RhinoStake](https://rhinostake.com/resources/berachain-apis)
+- [RouteMesh](https://routeme.sh)
 - [Spectrum](https://spectrumnodes.com)
 - [Tatum RPC and Webhooks](https://tatum.io/berachain-and-tatum)
 - [Tenderly](https://dashboard.tenderly.co/)

--- a/cn/build/getting-started/developer-tools.mdx
+++ b/cn/build/getting-started/developer-tools.mdx
@@ -36,6 +36,7 @@ Since Berachain is EVM-compatible, if you're familiar with creating dApps on oth
 - [Nirvana](https://nirvanalabs.io/nodes/berachain)
 - [QuickNode RPC](https://quicknode.notion.site/QuickNode-Benefits-for-Berachain-Developers-175d54ec5d644f598fde797633add2c1?pvs=4)
 - [RhinoStake](https://rhinostake.com/resources/berachain-apis)
+- [RouteMesh](https://routeme.sh)
 - [Spectrum](https://spectrumnodes.com)
 - [Tatum RPC and Webhooks](https://tatum.io/berachain-and-tatum)
 - [Tenderly](https://dashboard.tenderly.co/)

--- a/ko/build/getting-started/developer-tools.mdx
+++ b/ko/build/getting-started/developer-tools.mdx
@@ -36,6 +36,7 @@ Since Berachain is EVM-compatible, if you're familiar with creating dApps on oth
 - [Nirvana](https://nirvanalabs.io/nodes/berachain)
 - [QuickNode RPC](https://quicknode.notion.site/QuickNode-Benefits-for-Berachain-Developers-175d54ec5d644f598fde797633add2c1?pvs=4)
 - [RhinoStake](https://rhinostake.com/resources/berachain-apis)
+- [RouteMesh](https://routeme.sh)
 - [Spectrum](https://spectrumnodes.com)
 - [Tatum RPC and Webhooks](https://tatum.io/berachain-and-tatum)
 - [Tenderly](https://dashboard.tenderly.co/)

--- a/vi/build/getting-started/developer-tools.mdx
+++ b/vi/build/getting-started/developer-tools.mdx
@@ -36,6 +36,7 @@ Since Berachain is EVM-compatible, if you're familiar with creating dApps on oth
 - [Nirvana](https://nirvanalabs.io/nodes/berachain)
 - [QuickNode RPC](https://quicknode.notion.site/QuickNode-Benefits-for-Berachain-Developers-175d54ec5d644f598fde797633add2c1?pvs=4)
 - [RhinoStake](https://rhinostake.com/resources/berachain-apis)
+- [RouteMesh](https://routeme.sh)
 - [Spectrum](https://spectrumnodes.com)
 - [Tatum RPC and Webhooks](https://tatum.io/berachain-and-tatum)
 - [Tenderly](https://dashboard.tenderly.co/)


### PR DESCRIPTION
## Summary
- Add RouteMesh (`https://routeme.sh`) to the RPC and infrastructure providers list in the developer tools page.
- Apply the same provider entry across localized docs pages (`cn`, `ko`, and `vi`) to keep lists consistent.