### PR TITLE
docs(geth-deprecation): remove Geth, standardize on Bera-Reth

### DIFF
--- a/general/help/glossary.mdx
+++ b/general/help/glossary.mdx
@@ -71,10 +71,9 @@ The Engine API is the interface that allows communication between the execution 
 
 An EVM (Ethereum Virtual Machine) execution client is a software application responsible for the actual computation of transactions within blocks. It interprets and executes the code of smart contracts using the EVM, manages state changes, and executes the transaction logic.
 
-Supported EVM Execution Clients:
+Supported EVM Execution Client:
 
-- **Bera-Geth:** Berachain's fork of the official Go implementation of the Ethereum protocol
-- **Bera-Reth:** Berachain's fork of a popular Rust-based client focusing on performance and reliability
+- **Bera-Reth:** Berachain's fork of the Reth execution client, a Rust-based client focusing on performance and reliability
 
 ## Finality
 

--- a/general/introduction/what-is-berachain.mdx
+++ b/general/introduction/what-is-berachain.mdx
@@ -11,7 +11,7 @@ Berachain is an [EVM-identical](/general/introduction/what-is-berachain#evm-iden
 
 ## EVM Identical
 
-Berachain's execution runtime environment is identical to the Ethereum Virtual Machine (EVM) as seen on Ethereum Mainnet. Berachain uses very lightly modified forks of popular [execution clients](/general/help/glossary#execution-client) like Geth and Reth to handle executing smart contracts. Berachain supports all the [usual tooling](/build/getting-started/developer-tools) that is familiar to EVM developers.
+Berachain's execution runtime environment is identical to the Ethereum Virtual Machine (EVM) as seen on Ethereum Mainnet. Berachain uses a lightly modified fork of the popular [execution client](/general/help/glossary#execution-client) Reth (Bera-Reth) to handle executing smart contracts. Berachain supports all the [usual tooling](/build/getting-started/developer-tools) that is familiar to EVM developers.
 
 Identical means that whenever the EVM is upgraded, Berachain can adopt the latest version—for example, Dencun—straight out of the box. This includes compatibility with all RPC namespaces and endpoints, and any improvements made to execution clients can be applied immediately to Berachain.
 

--- a/nodes/architecture/evm-execution.mdx
+++ b/nodes/architecture/evm-execution.mdx
@@ -1,19 +1,18 @@
 ---
 title: "EVM Execution"
-description: "Recommended execution clients (Bera-Reth, Bera-Geth), versions, and genesis files for mainnet and Bepolia."
+description: "Recommended execution client (Bera-Reth), versions, and genesis files for mainnet and Bepolia."
 ---
 
-The execution layer consists of multiple implementations in the form of EVM execution clients. These clients handle transactions, transaction gossiping, state management, and support for the Ethereum Virtual Machine — they are not responsible for block building.
+The execution layer consists of an EVM execution client. This client handles transactions, transaction gossiping, state management, and support for the Ethereum Virtual Machine — it is not responsible for block building.
 
-The following execution clients are recommended to go with **[Beacon Kit v1.3.5](https://github.com/berachain/beacon-kit/releases/tag/v1.3.5)**.
+The following execution client is recommended to go with **[Beacon Kit v1.3.5](https://github.com/berachain/beacon-kit/releases/tag/v1.3.5)**.
 
 | Language | Required Version (Mainnet & Bepolia) |
 | -------- | ------------------------------------ |
-| Golang   | [Bera-Geth v1.011607.0](https://github.com/berachain/bera-geth/releases/tag/v1.011607.0) |
 | Rust     | [Bera-Reth v1.3.1](https://github.com/berachain/bera-reth/releases/tag/v1.3.1) |
 
-| Bera-Reth/Geth Genesis File | Updated | Download link & md5 hash |
-| --------------------------- | ------- | ------------------------ |
+| Genesis File | Updated | Download link & md5 hash |
+| ------------ | ------- | ------------------------ |
 | Mainnet | Nov 7 | [6b333924b81a1935e51ac70e7d9d7cb0](https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/80094/eth-genesis.json) |
 | Bepolia | Sep 15 | [c27c1162af33f7f5401bcef974a64454](https://raw.githubusercontent.com/berachain/beacon-kit/refs/heads/main/testing/networks/80069/eth-genesis.json) |
 

--- a/nodes/operations/monitoring.mdx
+++ b/nodes/operations/monitoring.mdx
@@ -7,7 +7,7 @@ Berachain nodes operate as a joined pair of execution layer and consensus layer.
 
 ## Prometheus and Grafana
 
-Prometheus is an open-source monitoring and alerting toolkit designed for reliability and scalability. It functions as a time series database that collects and stores metrics from monitored targets at regular intervals. Prometheus works on a pull-based model, where it scrapes HTTP endpoints exposed by services like `beacond` or `geth`. These services listen on dedicated ports and respond with metrics in a simple text-based format. For Berachain nodes, Prometheus is essential for tracking performance metrics, resource utilization, and operational health over time.
+Prometheus is an open-source monitoring and alerting toolkit designed for reliability and scalability. It functions as a time series database that collects and stores metrics from monitored targets at regular intervals. Prometheus works on a pull-based model, where it scrapes HTTP endpoints exposed by services like `beacond` or `bera-reth`. These services listen on dedicated ports and respond with metrics in a simple text-based format. For Berachain nodes, Prometheus is essential for tracking performance metrics, resource utilization, and operational health over time.
 
 Grafana is a visualization and analytics platform often paired with Prometheus. While Prometheus collects and stores metrics, Grafana provides a powerful interface to query, visualize, and understand that data through customizable dashboards. It allows node operators to create graphs, charts, and alerts based on Prometheus metrics, making it easier to monitor node performance, identify issues, and track the health of Berachain nodes over time.
 
@@ -57,7 +57,7 @@ scrape_configs:
         replacement: 127.0.0.1:9115
 ```
 
-In the above configuration, monitoring is set up to ensure port 26656 (a beacond instance) and 30303 (a reth/geth instance) are listening.
+In the above configuration, monitoring is set up to ensure port 26656 (a beacond instance) and 30303 (a bera-reth instance) are listening.
 
 When you restart Prometheus with this configuration, it should begin publishing a `probe_success` metric with a 0 or 1 value to indicate DOWN or UP.
 
@@ -91,7 +91,7 @@ With this enabled, beacond exports a considerable number of metrics. Here are so
 
 ## Execution layer metrics
 
-Both `geth` and `reth` allow you to enable metrics with identical command line options:
+Bera-Reth allows you to enable metrics with these command line options:
 
 ```bash
 --metrics
@@ -99,29 +99,17 @@ Both `geth` and `reth` allow you to enable metrics with identical command line o
 --metrics.addr 0.0.0.0
 ```
 
-The address should be either on a private network or not accessible to the public via firewall rule. `reth` publishes the metrics at `/metrics`, while `geth` uses `/debug/metrics/prometheus`.
+The address should be either on a private network or not accessible to the public via firewall rule. Bera-Reth publishes the metrics at `/metrics`.
 
-After restarting your EL to begin publishing metrics at your chosen port, add this endpoint to Prometheus. **You only need the one which matches your EL client:**
+After restarting your EL to begin publishing metrics at your chosen port, add this endpoint to Prometheus:
 
 ```yaml /etc/prometheus/prometheus.yml
 scrape_configs:
-  - job_name: geth
-    metrics_path: /debug/metrics/prometheus
-    static_configs:
-      - targets: ["localhost:9108"]
-
   - job_name: reth
     metrics_path: /metrics
     static_configs:
       - targets: ["localhost:9108"]
 ```
-
-### Geth metrics
-
-- `chain_head_finalized` — the chain height for the `_finalized` sync step
-- `eth_db_chaindata_disk_size` — the on-disk size of the chain data
-- `p2p_peers_inbound` and `p2p_peers_outbound` — the number of connections propagating transactions and blocks
-- `irate(txpool_known[5m])` — the number of new transactions introduced to the pool in the last 5 minutes, an indicator of successful peering
 
 ### Reth metrics
 

--- a/nodes/operations/production-checklist.mdx
+++ b/nodes/operations/production-checklist.mdx
@@ -29,9 +29,9 @@ Check that you are running a supported version of your [execution client](/nodes
 
 There are several ingredients to successful peering. If you are running in a containerized environment, ensure your services are properly advertising their real network address, and that traffic is being directed into the container, both for Beacon Kit and your execution client.
 
-1. **Check bootnodes for initial chain sync**: Check that you have a current list of [bootnodes](https://github.com/berachain/beacon-kit/blob/main/testing/networks/80094/el-bootnodes.txt). Both `geth` and `reth` accept the `--bootnodes` option. `beacond` has the boot node list baked into the distributed [config](https://github.com/berachain/beacon-kit/blob/main/testing/networks/80094/config.toml).
+1. **Check bootnodes for initial chain sync**: Check that you have a current list of [bootnodes](https://github.com/berachain/beacon-kit/blob/main/testing/networks/80094/el-bootnodes.txt). Bera-Reth accepts the `--bootnodes` option. `beacond` has the boot node list baked into the distributed [config](https://github.com/berachain/beacon-kit/blob/main/testing/networks/80094/config.toml).
 2. **Check Execution Layer peering**: The execution layer needs excellent peering to ensure that transactions flow to your validator for sealing in blocks. Ensure port 30303 TCP (for transactions) and UDP (for peer exchange) is open. Check that you have a current list of [bootnodes](https://github.com/berachain/beacon-kit/blob/main/testing/networks/80094/el-bootnodes.txt).
-3. **Indicate your Execution Layer's external IP address**: Execution clients need to know the publicly routable IP address they can be reached at. Most execution clients try to determine your public IP with UPnP, which is not available in cloud computing environments. Therefore, you must _tell your execution client_ what your external IP address is. For `reth` and `geth`, this is done with the `--nat extip:<IP>` option.
+3. **Indicate your Execution Layer's external IP address**: Execution clients need to know the publicly routable IP address they can be reached at. Most execution clients try to determine your public IP with UPnP, which is not available in cloud computing environments. Therefore, you must _tell your execution client_ what your external IP address is. For Bera-Reth, this is done with the `--nat extip:<IP>` option.
 4. **Check beacond peering**: `beacond` needs good peering to organize and perform consensus actions. This is carried out over TCP port 26656. Also, correctly advertise your node's external IP with `p2p.external_address` in `config.toml`. To limit `beacond`'s memory consumption, **40 inbound + 10 outbound peers** is recommended:
 
 ```toml
@@ -50,13 +50,7 @@ For **Reth**, the following options are recommended in the Reth launch:
 --engine.memory-block-buffer-target 0
 ```
 
-For **Geth**, override the gas price lower limit to agree with Reth:
-
-```bash
---miner.gasprice 1
-```
-
-For both clients, ensure the `debug` API is not enabled in the `--http.api` option. It is better to **remove** the `--http.api` option entirely and allow the secure default to apply, unless you have specific reasons to enable additional modules. For Geth, exposing the `debug` API module enables highly destructive commands.
+Ensure the `debug` API is not enabled in the `--http.api` option. It is better to **remove** the `--http.api` option entirely and allow the secure default to apply, unless you have specific reasons to enable additional modules.
 
 ## Register with the team
 

--- a/nodes/operations/quickstart.mdx
+++ b/nodes/operations/quickstart.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Quickstart: Run a Node"
-description: "Prerequisites, scripts, and steps to run Beacon-Kit and an execution client (Bera-Reth or Bera-Geth) on Linux or Mac."
+description: "Prerequisites, scripts, and steps to run Beacon-Kit and Bera-Reth on Linux or Mac."
 ---
 
-A Berachain node consists of two clients running together: a **consensus client** (Beacon-Kit) and an **execution client** (Bera-Reth or Bera-Geth). This guide walks you through setting up both on a Linux or Mac computer.
+A Berachain node consists of two clients running together: a **consensus client** (Beacon-Kit) and an **execution client** (Bera-Reth). This guide walks you through setting up both on a Linux or Mac computer.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ A Berachain node consists of two clients running together: a **consensus client*
 Install the required binaries before starting:
 
 1. **Beacon-Kit**: Download the appropriate binary from the [releases page](https://github.com/berachain/beacon-kit/releases) for your OS and architecture. Make it executable and place it in your PATH (e.g., `~/.local/bin/`).
-2. **Execution client**: Choose either [Bera-Reth](https://github.com/berachain/bera-reth/releases) or [Bera-Geth](https://github.com/berachain/bera-geth/releases). Download the binary for your OS and architecture, make it executable, and place it in your PATH.
+2. **Execution client**: Download [Bera-Reth](https://github.com/berachain/bera-reth/releases) for your OS and architecture. Make it executable and place it in your PATH.
 
 See [EVM Execution Clients](/nodes/architecture/evm-execution) for recommended versions.
 
@@ -28,7 +28,7 @@ Verify installation:
 
 ```bash
 beacond version
-bera-reth --version  # or bera-geth version
+bera-reth --version
 ```
 
 ## What you'll do
@@ -37,7 +37,7 @@ bera-reth --version  # or bera-geth version
 2. **Configure environment** — set environment variables for your network (mainnet or Bepolia) and node identity
 3. **Fetch parameters** — download genesis files and network configuration
 4. **Set up Beacon-Kit** — initialize the consensus client and generate keys
-5. **Set up execution client** — initialize Reth or Geth with the genesis state
+5. **Set up execution client** — initialize Reth with the genesis state
 6. **Fetch snapshots (optional)** — restore snapshots to speed up initial sync
 7. **Fetch address book (optional)** — download peer list for faster startup
 8. **Run both clients** — launch them in separate terminals; they communicate via JWT auth
@@ -67,14 +67,14 @@ rm -r guides;
 ls;
 
 # [Expected output, edited for clarity]
-# README.md                     run-geth.sh     setup-geth.sh
-# env.sh                        run-reth.sh     setup-reth.sh
-# fetch-berachain-params.sh     run-beacond.sh  setup-beacond.sh
+# README.md                     run-reth.sh     setup-reth.sh
+# env.sh                        run-beacond.sh  setup-beacond.sh
+# fetch-berachain-params.sh
 ```
 
 The file `env.sh` contains environment variables used in the other scripts.
 `fetch-berachain-params.sh` obtains copies of the genesis file and other configuration files.
-Then we have `setup-` and `run-` scripts for various execution clients and `beacond`.
+Then we have `setup-` and `run-` scripts for the execution client and `beacond`.
 
 ## Step 2 - Configure environment
 
@@ -96,7 +96,6 @@ export JWT_PATH=$BEACOND_CONFIG/jwt.hex
 export BEACOND_BIN=$(command -v beacond || echo $(pwd)/beacond)
 export BEACOND_DATA=$(pwd)/var/beacond
 export RETH_BIN=$(command -v bera-reth || echo $(pwd)/bera-reth)
-export GETH_BIN=$(command -v bera-geth || echo $(pwd)/bera-geth)
 ```
 
 You need to set these constants:
@@ -112,7 +111,7 @@ You should verify these constants:
 - **LOG_DIR**: This directory stores log files.
 - **BEACOND_BIN**: Set this to the full path where you installed `beacond`. The expression provided finds it in your $PATH.
 - **BEACOND_DATA**: Set this to where the consensus data and config should be kept.
-- **RETH_BIN** or other chain client: Set this to the full path where you installed the chain client.
+- **RETH_BIN**: Set this to the full path where you installed `bera-reth`. The expression provided finds it in your $PATH.
 
 ## Step 3 - Fetch parameters
 
@@ -166,11 +165,7 @@ Your validator state root **must** agree with the value shown above for your cho
 
 ## Step 5 - Set up the execution client
 
-The `setup-reth` and `setup-geth` scripts create a runtime directory and configuration for their respective chain clients. The scripts configure the node with pruning settings according to the `EL_ARCHIVE_NODE` setting in `env.sh`.
-
-**If you're using Bera-Reth**, run `setup-reth.sh`. **If you're using Bera-Geth**, run `setup-geth.sh` instead.
-
-Here's an example using `setup-reth`:
+The `setup-reth.sh` script creates a runtime directory and configuration for the execution client. It configures the node with pruning settings according to the `EL_ARCHIVE_NODE` setting in `env.sh`.
 
 ```bash
 # FROM: ~/beranode
@@ -210,7 +205,7 @@ Berachain and the community offer snapshots for Mainnet and Bepolia. You can dow
 node fetch-berachain-snapshot.js
 
 # Or specify options:
-node fetch-berachain-snapshot.js --client geth --network testnet --type archive
+node fetch-berachain-snapshot.js --network testnet --type archive
 
 # [Expected Output]:
 # Bera Snapshot Downloader
@@ -223,7 +218,6 @@ node fetch-berachain-snapshot.js --client geth --network testnet --type archive
 
 Available options:
 
-- `--client` or `-c`: Execution client (`reth` or `geth`, default: `reth`)
 - `--network` or `-n`: Network (`mainnet` or `testnet`, default: `mainnet`)
 - `--type` or `-t`: Snapshot type (`pruned` or `archive`, default: `pruned`)
 - `--help` or `-h`: Show help message
@@ -274,13 +268,13 @@ lz4 -d "$BEACON_SNAPSHOT" | tar xv -C var/beacond/;
 
 ### 6e - Install execution layer snapshot
 
-Extract the execution layer snapshot. The example below uses `reth` (for `geth`, use `var/geth/` or `var/bera-geth/`):
+Extract the execution layer snapshot:
 
 ```bash
 # FROM: ~/beranode
 
 # Find the execution layer snapshot
-EL_SNAPSHOT=$(ls downloads/snapshot_reth-*.tar.lz4 downloads/snapshot_geth-*.tar.lz4 2>/dev/null | head -1)
+EL_SNAPSHOT=$(ls downloads/snapshot_reth-*.tar.lz4 | head -1)
 lz4 -d "$EL_SNAPSHOT" | tar xv -C var/reth/;
 
 # [Expected Output]:

--- a/nodes/operations/self-hosted-rpc.mdx
+++ b/nodes/operations/self-hosted-rpc.mdx
@@ -39,7 +39,7 @@ We have a useful list of paid RPC providers on our [developer tools page](/build
 
 ## Running your own RPC
 
-If you need predictable throughput, hard isolation, or you cannot tolerate multi-tenant rate limits, the next step is operating a private RPC endpoint backed by your own node. A Berachain node has two components: the consensus layer, Beacon-Kit, and the execution layer, bera-reth or bera-geth. For setup instructions, use the node [Quickstart](/nodes/operations/quickstart), which stays current as tooling changes.
+If you need predictable throughput, hard isolation, or you cannot tolerate multi-tenant rate limits, the next step is operating a private RPC endpoint backed by your own node. A Berachain node has two components: the consensus layer, Beacon-Kit, and the execution layer, Bera-Reth. For setup instructions, use the node [Quickstart](/nodes/operations/quickstart), which stays current as tooling changes.
 
 ## Reliability and pricing
 


### PR DESCRIPTION
## Summary

Remove deprecated Geth references and standardize documentation on Bera-Reth as the primary execution client.

## Changes

- Update glossary to list only Bera-Reth as supported execution client
- Remove Geth from architecture and introduction docs  
- Update monitoring docs to reference bera-reth instead of geth/reth
- Simplify execution layer documentation to reflect single-client focus

## Related

Coordinated with geth deprecation work in [berachain/guides](https://github.com/berachain/guides) (chore/geth-deprecation branch)