### PR TITLE
docs: Bepolia Berascan URL is testnet.berascan.com

### DIFF
--- a/general/introduction/connect-to-berachain.mdx
+++ b/general/introduction/connect-to-berachain.mdx
@@ -115,7 +115,7 @@ Use these values for the testnet. Add in one click, or copy from the table:
 | -------- | ----------------------------------- |
 | Hub      | https://bepolia.hub.berachain.com   |
 | BEX      | Not publicly available on Bepolia   |
-| Berascan | https://bepolia.berascan.com        |
+| Berascan | https://testnet.berascan.com        |
 | Honey    | https://bepolia.honey.berachain.com |
 
 ## Supported Wallets


### PR DESCRIPTION
fix a vibecoded block explorer URL