### PR TITLE
docs(readme): add 'Tracked on web3-discover' badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Berachain Documentation
 
+[![Tracked on web3-discover](https://web3-discover.vercel.app/badge/berachain-post-tge-incentives.svg)](https://web3-discover.vercel.app/airdrops/berachain-post-tge-incentives)
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/berachain/docs/blob/main/CONTRIBUTING.md)
 [![Contributors](https://img.shields.io/github/contributors/berachain/docs)](https://github.com/berachain/docs/graphs/contributors)


### PR DESCRIPTION
Hi — this adds a small README badge linking to this project's listing on **[web3-discover](https://web3-discover.vercel.app)**, an honest hand-curated directory of currently-active airdrops and on-chain incentive programs (no paid placements, scam-filtered, risk-flagged).

The listing for this project: https://web3-discover.vercel.app/airdrops/berachain-post-tge-incentives

The badge renders as:
> [![Tracked on web3-discover](https://web3-discover.vercel.app/badge/berachain-post-tge-incentives.svg)](https://web3-discover.vercel.app/airdrops/berachain-post-tge-incentives)

It's a single line near the top of the README and doesn't touch anything else. If you'd rather not host a third-party badge here, no problem — please feel free to close. I won't follow up.

— [@west0nG](https://github.com/west0nG)