### PR TITLE
docs(nodes): recommend Beacon Kit and Bera-Reth v1.4.0

### DIFF
--- a/nodes/architecture/evm-execution.mdx
+++ b/nodes/architecture/evm-execution.mdx
@@ -9,17 +9,17 @@ The execution layer consists of an EVM execution client. This client handles tra
 
 Recommended **[Beacon Kit](https://github.com/berachain/beacon-kit)** and **[Bera-Reth](https://github.com/berachain/bera-reth)** versions depend on the network:
 
-| Network | Beacon Kit                                                                    | Bera-Reth                                                                    |
-| ------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Mainnet | [v1.3.9](https://github.com/berachain/beacon-kit/releases/tag/v1.3.9)         | [v1.3.3](https://github.com/berachain/bera-reth/releases/tag/v1.3.3)         |
-| Bepolia | [v1.4.0-rc3](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0-rc3) | [v1.4.0-rc2](https://github.com/berachain/bera-reth/releases/tag/v1.4.0-rc2) |
+| Network | Beacon Kit                                                              | Bera-Reth                                                              |
+| ------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Mainnet | [v1.4.0](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0)   | [v1.4.0](https://github.com/berachain/bera-reth/releases/tag/v1.4.0)   |
+| Bepolia | [v1.4.0](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0)   | [v1.4.0](https://github.com/berachain/bera-reth/releases/tag/v1.4.0)   |
 
 As of 1.4.0, Bera-Reth includes the genesis file, which can be used with the option `--chain (bepolia|mainnet)` instead of `--chain <path>`.  
 You can continue to specify the genesis file path, but be sure to verify its hash:
 
 | Genesis File | Updated      | Download link & md5 hash                                                                                                                      |
 | ------------ | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Mainnet      | Nov 7, 2025  | [6b333924b81a1935e51ac70e7d9d7cb0](https://raw.githubusercontent.com/berachain/beacon-kit/v1.3.9/testing/networks/80094/eth-genesis.json)     |
-| Bepolia      | May 13, 2026 | [dfa4cb7a11217c9eab6cf4b405368870](https://raw.githubusercontent.com/berachain/beacon-kit/v1.4.0-rc3/testing/networks/80069/eth-genesis.json) |
+| Mainnet      | Jun 8, 2026  | [13f51cd28e26aaa308f0ee9d3cb3c966](https://raw.githubusercontent.com/berachain/beacon-kit/v1.4.0/testing/networks/80094/eth-genesis.json)     |
+| Bepolia      | May 13, 2026 | [dfa4cb7a11217c9eab6cf4b405368870](https://raw.githubusercontent.com/berachain/beacon-kit/v1.4.0/testing/networks/80069/eth-genesis.json) |
 
 Installing a more recent patch version — the `z` in a version number `x.y.z` — is generally safe.

--- a/nodes/architecture/evm-execution.mdx
+++ b/nodes/architecture/evm-execution.mdx
@@ -7,12 +7,7 @@ Berachain is 100% EVM-compatible, operating on a lightly modified Reth. We keep 
 
 The execution layer consists of an EVM execution client. This client handles transactions, transaction gossiping, state management, and support for the Ethereum Virtual Machine — it is not responsible for block building.
 
-Recommended **[Beacon Kit](https://github.com/berachain/beacon-kit)** and **[Bera-Reth](https://github.com/berachain/bera-reth)** versions depend on the network:
-
-| Network | Beacon Kit                                                              | Bera-Reth                                                              |
-| ------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Mainnet | [v1.4.0](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0)   | [v1.4.0](https://github.com/berachain/bera-reth/releases/tag/v1.4.0)   |
-| Bepolia | [v1.4.0](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0)   | [v1.4.0](https://github.com/berachain/bera-reth/releases/tag/v1.4.0)   |
+Recommended **[Beacon Kit](https://github.com/berachain/beacon-kit)** [v1.4.0](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0) and **[Bera-Reth](https://github.com/berachain/bera-reth)** [v1.4.0](https://github.com/berachain/bera-reth/releases/tag/v1.4.0).
 
 As of 1.4.0, Bera-Reth includes the genesis file, which can be used with the option `--chain (bepolia|mainnet)` instead of `--chain <path>`.  
 You can continue to specify the genesis file path, but be sure to verify its hash:

--- a/nodes/operations/fusaka.mdx
+++ b/nodes/operations/fusaka.mdx
@@ -13,7 +13,6 @@ Fusaka is the Berachain upgrade that activates the [Fulu + Osaka EL/CL changes](
 | Mainnet         | 4pm June 24, 2026     | June 9             |
 
 **Beacon Kit v1.4.0** and **Bera-Reth v1.4.0** are available on GitHub ([Bera-Reth](https://github.com/berachain/bera-reth/releases/tag/v1.4.0), [BeaconKit](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0)).
-Announcements also go to [Telegram](https://t.me/beranodes/) and [Discord](https://discord.gg/berachain/).
 
 ## Bera-Geth Will Stop Working
 

--- a/nodes/operations/fusaka.mdx
+++ b/nodes/operations/fusaka.mdx
@@ -10,10 +10,9 @@ Fusaka is the Berachain upgrade that activates the [Fulu + Osaka EL/CL changes](
 | Network         | Activation Date (UTC) | Binaries Available |
 | --------------- | --------------------- | ------------------ |
 | Bepolia Testnet | 4pm May 27, 2026      | May 11             |
-| Mainnet         | 4pm June 24, 2026     | June 8             |
+| Mainnet         | 4pm June 24, 2026     | June 9             |
 
 **Beacon Kit v1.4.0** and **Bera-Reth v1.4.0** are available on GitHub ([Bera-Reth](https://github.com/berachain/bera-reth/releases/tag/v1.4.0), [BeaconKit](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0)).
-Install them from our [recommended versions](/nodes/architecture/evm-execution) page before the activation date for your network.
 Announcements also go to [Telegram](https://t.me/beranodes/) and [Discord](https://discord.gg/berachain/).
 
 ## Bera-Geth Will Stop Working

--- a/nodes/operations/fusaka.mdx
+++ b/nodes/operations/fusaka.mdx
@@ -12,8 +12,9 @@ Fusaka is the Berachain upgrade that activates the [Fulu + Osaka EL/CL changes](
 | Bepolia Testnet | 4pm May 27, 2026      | May 11             |
 | Mainnet         | 4pm June 24, 2026     | June 8             |
 
-The official binaries will ship at GitHub ([Bera-Reth](https://github.com/berachain/bera-reth/releases), [BeaconKit](https://github.com/berachain/beacon-kit/releases)),
-with announcements posted to [Telegram](https://t.me/beranodes/) and [Discord](https://discord.gg/berachain/), along with updates to our [recommended versions](/nodes/architecture/evm-execution) page.
+**Beacon Kit v1.4.0** and **Bera-Reth v1.4.0** are available on GitHub ([Bera-Reth](https://github.com/berachain/bera-reth/releases/tag/v1.4.0), [BeaconKit](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0)).
+Install them from our [recommended versions](/nodes/architecture/evm-execution) page before the activation date for your network.
+Announcements also go to [Telegram](https://t.me/beranodes/) and [Discord](https://discord.gg/berachain/).
 
 ## Bera-Geth Will Stop Working
 
@@ -54,13 +55,12 @@ With this approach, there is no longer any need to manually fetch or deploy upda
 The old style of `--chain <path>` still works, but you must be sure to fetch and deploy the genesis files linked from our [release page](/nodes/architecture/evm-execution).
 
 1. **If you are running Bera-Geth, you [have to migrate to Bera-Reth](/nodes/operations/bera-geth-to-reth).**
-2. **DO NOT deploy this on a mainnet node** until 1.4.0 (non-rc) binaries designated for mainnet are released.
-3. Download the current releases of BeaconKit and Bera-Reth from the [recommended versions](/nodes/architecture/evm-execution) page.
-4. Adjust Bera-Reth startup:
-   - Change your <span style={{ whiteSpace: "nowrap" }}>`--chain`</span> option to <span style={{ whiteSpace: "nowrap" }}>`--chain bepolia`</span> and remove <span style={{ whiteSpace: "nowrap" }}>`--bootnodes`</span>.
-   - OR download and fetch the current bepolia genesis file from the [recommended versions](/nodes/architecture/evm-execution) page, and overwrite your current genesis file with it.
-5. No changes are needed to BeaconKit options.
-6. Start the new `beacond` and `bera-reth` binaries.
+2. Download **Beacon Kit v1.4.0** and **Bera-Reth v1.4.0** from the [recommended versions](/nodes/architecture/evm-execution) page. Deploy on every node before the Fusaka activation date for your network.
+3. Adjust Bera-Reth startup:
+   - **Preferred:** set <span style={{ whiteSpace: "nowrap" }}>`--chain`</span> to <span style={{ whiteSpace: "nowrap" }}>`--chain bepolia`</span> or <span style={{ whiteSpace: "nowrap" }}>`--chain mainnet`</span> (matching your network) and remove <span style={{ whiteSpace: "nowrap" }}>`--bootnodes`</span>.
+   - **Alternative:** download the current genesis file for your network from the [recommended versions](/nodes/architecture/evm-execution) page, overwrite your existing genesis file, and keep <span style={{ whiteSpace: "nowrap" }}>`--chain <path>`</span>.
+4. No changes are needed to BeaconKit options.
+5. Start the new `beacond` and `bera-reth` binaries.
 
 ## Support
 

--- a/nodes/operations/quickstart.mdx
+++ b/nodes/operations/quickstart.mdx
@@ -130,7 +130,7 @@ The `fetch-berachain-params.sh` script downloads the key network parameters for 
 
 # [Expected Output for bepolia - verify these checksums]:
 # a24fb9c7ddf3ebd557300e989d44b619  seed-data-80069/genesis.json
-# c27c1162af33f7f5401bcef974a64454  seed-data-80069/eth-genesis.json
+# dfa4cb7a11217c9eab6cf4b405368870  seed-data-80069/eth-genesis.json
 # 5d0d482758117af8dfc20e1d52c31eef  seed-data-80069/kzg-trusted-setup.json
 ```
 

--- a/nodes/operations/quickstart.mdx
+++ b/nodes/operations/quickstart.mdx
@@ -125,7 +125,7 @@ The `fetch-berachain-params.sh` script downloads the key network parameters for 
 
 # [Expected Output for mainnet - verify these checksums]:
 # c66dbea5ee3889e1d0a11f856f1ab9f0  seed-data-80094/genesis.json
-# 6b333924b81a1935e51ac70e7d9d7cb0  seed-data-80094/eth-genesis.json
+# 13f51cd28e26aaa308f0ee9d3cb3c966  seed-data-80094/eth-genesis.json
 # 5d0d482758117af8dfc20e1d52c31eef  seed-data-80094/kzg-trusted-setup.json
 
 # [Expected Output for bepolia - verify these checksums]:


### PR DESCRIPTION
## Summary

- Update [EVM Execution](https://docs.berachain.com/nodes/architecture/evm-execution) to recommend **v1.4.0** for Beacon Kit and Bera-Reth on both mainnet and Bepolia (replacing v1.3.9/v1.3.3 and the 1.4.0-rc tags).
- Refresh the mainnet `eth-genesis.json` md5 to `13f51cd28e26aaa308f0ee9d3cb3c966` from the `beacon-kit/v1.4.0` tag.
- Point genesis download URLs at `v1.4.0` for both networks.
- Align the mainnet `eth-genesis.json` checksum in the node quickstart.

## Test plan

- [x] Verify mainnet genesis md5: `curl -sL https://raw.githubusercontent.com/berachain/beacon-kit/v1.4.0/testing/networks/80094/eth-genesis.json | md5`
- [x] Verify Bepolia genesis md5: `curl -sL https://raw.githubusercontent.com/berachain/beacon-kit/v1.4.0/testing/networks/80069/eth-genesis.json | md5`
- [x] Confirm release links resolve to a release page: [beacon-kit v1.4.0](https://github.com/berachain/beacon-kit/releases/tag/v1.4.0), [bera-reth v1.4.0](https://github.com/berachain/bera-reth/releases/tag/v1.4.0)