### PR TITLE
Update SubQuery Bepolia guide link

### DIFF
--- a/build/guides/community/overview.mdx
+++ b/build/guides/community/overview.mdx
@@ -51,7 +51,7 @@ These are a list of community developer guides for Berachain.
 | Index & Query Berachain Data with Goldsky   | [GitHub](https://github.com/berachain/guides/tree/main/apps/goldsky-subgraph)                                                               |
 | Index & Query Berachain Data with The Graph | [Guide](https://thegraph.com/docs/en/subgraphs/quick-start/)                                                                                |
 | Envio Indexer ERC20                         | [GitHub](https://github.com/berachain/guides/tree/main/apps/envio-indexer-erc20)                                                            |
-| Index & Query Berachain Data with SubQuery  | [Guide](https://subquery.network/doc/indexer/quickstart/quickstart_chains/berachain-artio-testnet.html#berachain-artio-testnet-quick-start) |
+| Index & Query Berachain Data with SubQuery  | [Guide](https://subquery.network/indexer/berachain-bepolia-testnet)                                                                         |
 
 ## Verifiable Randomness
 


### PR DESCRIPTION
## Summary
- Replace the stale SubQuery Berachain Artio quickstart link with the Bepolia SubQuery page.

## Test plan
- Searched docs worktree for `artio` / `bartio`; no content matches remain.