### PR TITLE
docs(nodes): align quickstart with chain-slug node scripts

### DIFF
--- a/nodes/operations/fusaka.mdx
+++ b/nodes/operations/fusaka.mdx
@@ -10,10 +10,7 @@ Fusaka is the Berachain upgrade that activates the [Fulu + Osaka EL/CL changes](
 | Network         | Activation Date (UTC) | Binaries Available |
 | --------------- | --------------------- | ------------------ |
 | Bepolia Testnet | 4pm May 27, 2026      | May 11             |
-| Mainnet         | TBD coming soon       | soon               |
-
-The official binaries will ship at GitHub ([Bera-Reth](https://github.com/berachain/bera-reth/releases), [BeaconKit](https://github.com/berachain/beacon-kit/releases)),
-with announcements posted to [Telegram](https://t.me/beranodes/) and [Discord](https://discord.gg/berachain/), along with updates to our [recommended versions](/nodes/architecture/evm-execution) page.
+| Mainnet         | 4pm July 8, 2026      | June 23            |
 
 ## Bera-Geth Will Stop Working
 
@@ -54,7 +51,7 @@ With this approach, there is no longer any need to manually fetch or deploy upda
 The old style of `--chain <path>` still works, but you must be sure to fetch and deploy the genesis files linked from our [release page](/nodes/architecture/evm-execution).
 
 1. **If you are running Bera-Geth, you [have to migrate to Bera-Reth](/nodes/operations/bera-geth-to-reth).**
-2. **DO NOT deploy this on a mainnet node** until 1.4.1 binaries designated for mainnet are released - approx June 22.
+2. Download the [recommended versions](/nodes/architecture/evm-execution).
 3. Once released, obtain release binaries of BeaconKit and Bera-Reth from the [recommended versions](/nodes/architecture/evm-execution) page.
 4. Adjust Bera-Reth startup:
    - Change your <span style={{ whiteSpace: "nowrap" }}>`--chain`</span> option to <span style={{ whiteSpace: "nowrap" }}>`--chain bepolia`</span> and remove <span style={{ whiteSpace: "nowrap" }}>`--bootnodes [enode-list]`</span>.

--- a/nodes/operations/quickstart.mdx
+++ b/nodes/operations/quickstart.mdx
@@ -17,12 +17,10 @@ A Berachain node consists of two clients running together: a **consensus client*
 
 ### Software
 
-Install **Beacon Kit v1.4.1** and **Bera-Reth v1.4.1** (or later) before starting:
+Install the current recommended **Beacon Kit** and **Bera-Reth** releases for your network ([EVM Execution Clients](/nodes/architecture/evm-execution)) before starting:
 
 1. **BeaconKit**: Download the appropriate binary from the [releases page](https://github.com/berachain/beacon-kit/releases) for your OS and architecture. Make it executable and place it in your PATH (e.g., `~/.local/bin/`).
 2. **Execution client**: Download [Bera-Reth](https://github.com/berachain/bera-reth/releases) for your OS and architecture. Make it executable and place it in your PATH.
-
-See [EVM Execution Clients](/nodes/architecture/evm-execution) for recommended versions.
 
 Verify installation:
 
@@ -30,6 +28,8 @@ Verify installation:
 beacond version
 bera-reth --version
 ```
+
+Both commands should report the current release for your network on [EVM Execution Clients](/nodes/architecture/evm-execution).
 
 ## What you'll do
 
@@ -151,7 +151,7 @@ The script `setup-beacond.sh` invokes `beacond init` and `beacond jwt generate`.
 # [Expected Output]:
 # BEACOND_DATA: /.../var/beacond
 # BEACOND_BIN: /.../bin/beacond
-#   Version: v1.4.1
+#   Version: …
 # ✓ Private validator key generated in .../priv_validator_key.json
 # ✓ JWT secret generated at [...]config]/jwt.hex
 # ✓ Config files in [...]beacond/config updated
@@ -175,7 +175,7 @@ The `setup-reth.sh` script creates the Reth datadir and initializes it with `--c
 # RETH_DATA: /.../var/reth/data
 # RETH_BIN: /.../bin/bera-reth
 #   Chain: mainnet
-#   Version: v1.4.1
+#   Version: …
 # ✓ Reth set up.
 ```
 
@@ -307,7 +307,7 @@ Launch two terminal windows. In the first, run the consensus client:
 # [Expected Output]:
 # INFO Waiting for execution client to start... 🍺🕔
 # INFO Connected to execution client
-# INFO Reporting version v1.4.1
+# INFO Reporting version …
 # [AFTER BLOCKS START FLOWING]
 # INFO processExecutionPayload ... height=49 ...
 # INFO Finalized block ... height=49 ...

--- a/nodes/operations/quickstart.mdx
+++ b/nodes/operations/quickstart.mdx
@@ -17,10 +17,10 @@ A Berachain node consists of two clients running together: a **consensus client*
 
 ### Software
 
-Install the current recommended **Beacon Kit** and **Bera-Reth** releases for your network ([EVM Execution Clients](/nodes/architecture/evm-execution)) before starting:
+Check [EVM Execution Clients](/nodes/architecture/evm-execution) for the current recommended **Beacon Kit** and **Bera-Reth** releases for your network, then download each binary from its GitHub release page:
 
-1. **BeaconKit**: Download the appropriate binary from the [releases page](https://github.com/berachain/beacon-kit/releases) for your OS and architecture. Make it executable and place it in your PATH (e.g., `~/.local/bin/`).
-2. **Execution client**: Download [Bera-Reth](https://github.com/berachain/bera-reth/releases) for your OS and architecture. Make it executable and place it in your PATH.
+1. **BeaconKit** — on the [Beacon Kit releases page](https://github.com/berachain/beacon-kit/releases), open the tagged release for your network and download the build for your OS and architecture. Make it executable and place it in your PATH (e.g., `~/.local/bin/`).
+2. **Bera-Reth** — on the [Bera-Reth releases page](https://github.com/berachain/bera-reth/releases), open the matching tagged release and download the build for your OS and architecture. Make it executable and place it in your PATH.
 
 Verify installation:
 
@@ -29,7 +29,7 @@ beacond version
 bera-reth --version
 ```
 
-Both commands should report the current release for your network on [EVM Execution Clients](/nodes/architecture/evm-execution).
+Both commands should report the release listed for your network on [EVM Execution Clients](/nodes/architecture/evm-execution).
 
 ## What you'll do
 

--- a/nodes/operations/quickstart.mdx
+++ b/nodes/operations/quickstart.mdx
@@ -17,7 +17,7 @@ A Berachain node consists of two clients running together: a **consensus client*
 
 ### Software
 
-Install the required binaries before starting:
+Install **Beacon Kit v1.4.1** and **Bera-Reth v1.4.1** (or later) before starting:
 
 1. **BeaconKit**: Download the appropriate binary from the [releases page](https://github.com/berachain/beacon-kit/releases) for your OS and architecture. Make it executable and place it in your PATH (e.g., `~/.local/bin/`).
 2. **Execution client**: Download [Bera-Reth](https://github.com/berachain/bera-reth/releases) for your OS and architecture. Make it executable and place it in your PATH.
@@ -34,10 +34,10 @@ bera-reth --version
 ## What you'll do
 
 1. **Download scripts** — clone helper scripts that automate configuration
-2. **Configure environment** — set environment variables for your network (mainnet or Bepolia) and node identity
-3. **Fetch parameters** — download genesis files and network configuration
+2. **Configure environment** — set environment variables for your network (`mainnet` or `bepolia`) and node identity
+3. **Fetch parameters** — download consensus-layer genesis and network configuration
 4. **Set up BeaconKit** — initialize the consensus client and generate keys
-5. **Set up execution client** — initialize Reth with the genesis state
+5. **Set up execution client** — initialize the Reth datadir for your chain
 6. **Fetch snapshots (optional)** — restore snapshots to speed up initial sync
 7. **Run both clients** — launch them in separate terminals; they communicate via JWT auth
 
@@ -74,8 +74,8 @@ ls;
 ```
 
 The file `env.sh` contains environment variables used in the other scripts.
-`fetch-berachain-params.sh` obtains copies of the genesis file and other configuration files.
-Then we have `setup-` and `run-` scripts for the execution client and `beacond`.
+`fetch-berachain-params.sh` downloads consensus-layer configuration files.
+`setup-` and `run-` scripts start the execution client and `beacond`.
 
 ## Step 2 - Configure environment
 
@@ -85,7 +85,7 @@ Edit `env.sh` to set your node's configuration. Open the file and modify these v
 #!/bin/bash
 
 # CHANGE THESE VALUES
-export CHAIN_SPEC=mainnet   # or "testnet"
+export CHAIN=mainnet   # mainnet or bepolia
 export MONIKER_NAME=camembera
 export WALLET_ADDRESS_FEE_RECIPIENT=0x8b30eb59e9b2354825503d5e60845eb41d4caf36
 export EL_ARCHIVE_NODE=false # set to true if you want to run an archive node on CL and EL
@@ -101,7 +101,7 @@ export RETH_BIN=$(command -v bera-reth || echo $(pwd)/bera-reth)
 
 You need to set these constants:
 
-1. **CHAIN_SPEC**: Set to `testnet` or `mainnet`.
+1. **CHAIN**: Set to `mainnet` or `bepolia`.
 2. **MONIKER_NAME**: A name of your choice for your node.
 3. **WALLET_ADDRESS_FEE_RECIPIENT**: The address that receives priority fees for blocks sealed by your node. If your node will not be a validator, this won't matter.
 4. **EL_ARCHIVE_NODE**: Set to `true` if you want the execution client to be a full archive node.
@@ -116,7 +116,7 @@ You should verify these constants:
 
 ## Step 3 - Fetch parameters
 
-The `fetch-berachain-params.sh` script downloads the key network parameters for the chain you have configured:
+The `fetch-berachain-params.sh` script downloads consensus-layer network parameters for the chain you configured:
 
 ```bash
 # FROM: ~/beranode
@@ -125,23 +125,14 @@ The `fetch-berachain-params.sh` script downloads the key network parameters for 
 
 # [Expected Output for mainnet - verify these checksums]:
 # c66dbea5ee3889e1d0a11f856f1ab9f0  seed-data-80094/genesis.json
-# 6b333924b81a1935e51ac70e7d9d7cb0  seed-data-80094/eth-genesis.json
 # 5d0d482758117af8dfc20e1d52c31eef  seed-data-80094/kzg-trusted-setup.json
 
 # [Expected Output for bepolia - verify these checksums]:
 # a24fb9c7ddf3ebd557300e989d44b619  seed-data-80069/genesis.json
-# dfa4cb7a11217c9eab6cf4b405368870  seed-data-80069/eth-genesis.json
 # 5d0d482758117af8dfc20e1d52c31eef  seed-data-80069/kzg-trusted-setup.json
 ```
 
-Verify that the checksums for `genesis.json`, `eth-genesis.json`, and `kzg-trusted-setup.json` match the values above for your chosen network.
-
-<Tip>
-  Fusaka networks require the EL genesis JSON to include a `depositContractAddress` field under
-  `config`. The default Berachain `eth-genesis.json` for mainnet (`80094`) and bepolia (`80069`)
-  already includes this field; if you maintain a custom genesis template, add it as
-  `"depositContractAddress": "0x4242424242424242424242424242424242424242"`.
-</Tip>
+Verify that the checksums for `genesis.json` and `kzg-trusted-setup.json` match the values above for your chosen network.
 
 ## Step 4 - Set up BeaconKit
 
@@ -150,7 +141,7 @@ The script `setup-beacond.sh` invokes `beacond init` and `beacond jwt generate`.
 1. Runs `beacond init` to create the file `var/beacond/config/priv_validator_key.json`. This contains your node's private key. Especially if you intend to become a validator, keep this file safe. It cannot be regenerated, and losing it means you will not be able to participate in the consensus process.
 2. Runs `beacond jwt generate` to create the file `jwt.hex`. This contains a secret shared between the consensus client and execution client so they can securely communicate. If you suspect it has been leaked, delete it then generate a new one with `beacond jwt generate -o $JWT_PATH`.
 3. Rewrites the `beacond` configuration files to reflect settings chosen in `env.sh`.
-4. Places the mainnet parameters where BeaconKit expects them and shows you an important hash from the genesis file.
+4. Places network parameters where BeaconKit expects them and shows you an important hash from the genesis file.
 
 ```bash
 # FROM: ~/beranode
@@ -160,7 +151,7 @@ The script `setup-beacond.sh` invokes `beacond init` and `beacond jwt generate`.
 # [Expected Output]:
 # BEACOND_DATA: /.../var/beacond
 # BEACOND_BIN: /.../bin/beacond
-#   Version: v1.1.3
+#   Version: v1.4.1
 # ✓ Private validator key generated in .../priv_validator_key.json
 # ✓ JWT secret generated at [...]config]/jwt.hex
 # ✓ Config files in [...]beacond/config updated
@@ -173,7 +164,7 @@ Your validator state root **must** agree with the value shown above for your cho
 
 ## Step 5 - Set up the execution client
 
-The `setup-reth.sh` script creates a runtime directory and configuration for the execution client. It configures the node with pruning settings according to the `EL_ARCHIVE_NODE` setting in `env.sh`.
+The `setup-reth.sh` script creates the Reth datadir and initializes it with `--chain` set to your configured network (`mainnet` or `bepolia`). Pruning follows the `EL_ARCHIVE_NODE` setting in `env.sh`.
 
 ```bash
 # FROM: ~/beranode
@@ -181,12 +172,12 @@ The `setup-reth.sh` script creates a runtime directory and configuration for the
 ./setup-reth.sh;
 
 # [Expected Output]:
-# INFO [BEPOLIA] Genesis block written hash=0x0207661de38f0e54ba91c8286096e72486784c79dc6a9681fc486b38335c042f
-# INFO [MAINNET] Genesis block written hash=0xd57819422128da1c44339fc7956662378c17e2213e669b427ac91cd11dfcfb38
-# ✓ bera-reth set up.
+# RETH_DATA: /.../var/reth/data
+# RETH_BIN: /.../bin/bera-reth
+#   Chain: mainnet
+#   Version: v1.4.1
+# ✓ Reth set up.
 ```
-
-Your genesis block hash **must** agree with the above for your chosen chain.
 
 ## Step 6 - Fetch snapshots (optional)
 
@@ -214,7 +205,7 @@ Berachain and the community offer snapshots for Mainnet and Bepolia. You can dow
 node fetch-berachain-snapshot.js
 
 # Examples:
-node fetch-berachain-snapshot.js --network testnet --type archive
+node fetch-berachain-snapshot.js --network bepolia --type archive
 node fetch-berachain-snapshot.js -o /var/snapshots --execution-only
 
 # [Expected Output]:
@@ -232,7 +223,7 @@ node fetch-berachain-snapshot.js -o /var/snapshots --execution-only
 
 Available options:
 
-- `--network` or `-n`: `mainnet` or `testnet` (default: `mainnet`; selects the snapshot index host as above)
+- `--network` or `-n`: `mainnet` or `bepolia` (default: `mainnet`)
 - `--type` or `-t`: `pruned` or `archive` (default: `pruned`)
 - `--output` or `-o`: Download directory (default: `downloads` in the current working directory)
 - `--el-client`: Execution snapshot type prefix in the CSV (default: `reth`)
@@ -258,12 +249,13 @@ $BEACOND_BIN --home $BEACOND_HOME comet unsafe-reset-all;
 # Removed all blockchain history dir=var/beacond/data
 # Reset private validator file to genesis state key=..
 
-ls var/reth;
+ls var/reth/data;
 
 # [Expected Output]:
-# data  genesis.json
+# (empty or prior db contents)
 
 rm -r var/reth/data;
+mkdir -p var/reth/data;
 ```
 
 ### 6d - Install BeaconKit snapshot
@@ -286,7 +278,7 @@ lz4 -d "$BEACON_SNAPSHOT" | tar xv -C var/beacond/;
 
 ### 6e - Install execution layer snapshot
 
-Official Reth snapshot archives list **`db/`**, **`rocksdb/`**, and **`blobstore/`** at the **root** of the tarball (not under a `data/` directory). Your `bera-reth node --datadir` must be the directory that contains those folders. In this layout that is `var/reth/data` (see `setup-reth.sh` / `env.sh`), so pass **`-C var/reth/data`** to `tar`. Extracting into `var/reth/` would place `db/` next to `genesis.json` and would not match `--datadir`.
+Official Reth snapshot archives list **`db/`**, **`rocksdb/`**, and **`blobstore/`** at the **root** of the tarball (not under a `data/` directory). Your `bera-reth node --datadir` must be the directory that contains those folders. In this layout that is `var/reth/data` (see `setup-reth.sh` / `env.sh`), so pass **`-C var/reth/data`** to `tar`.
 
 ```bash
 # FROM: ~/beranode
@@ -315,13 +307,13 @@ Launch two terminal windows. In the first, run the consensus client:
 # [Expected Output]:
 # INFO Waiting for execution client to start... 🍺🕔
 # INFO Connected to execution client
-# INFO Reporting version v1.1.3
+# INFO Reporting version v1.4.1
 # [AFTER BLOCKS START FLOWING]
 # INFO processExecutionPayload ... height=49 ...
 # INFO Finalized block ... height=49 ...
 ```
 
-In the second, run the execution client. Here it is for Bera-Reth:
+In the second, run the execution client:
 
 ```bash
 # FROM: ~/beranode


### PR DESCRIPTION
## Summary
- Document `CHAIN=mainnet|bepolia` and Beacon Kit / Bera-Reth v1.4.1+ requirements
- Step 3 verifies CL genesis and KZG checksums only (no EL genesis fetch)
- Step 5 initializes Reth with the chain slug; snapshot examples use `--network bepolia`

Pairs with berachain/guides node-scripts update (merge guides first or together).

## Test plan
- [x] Review quickstart Step 2 env snippet matches `guides/apps/node-scripts/env.sh`
- [x] Confirm Step 3 checksums match `fetch-berachain-params.sh` output for mainnet and bepolia
- [x] Verify no references to `testnet`, EL genesis paths, or bootnodes in quickstart