### PR TITLE
docs(developer-tools): reference OpenChainBench for live Berachain RPC latency

### DIFF
--- a/build/getting-started/developer-tools.mdx
+++ b/build/getting-started/developer-tools.mdx
@@ -44,6 +44,8 @@ Since Berachain is EVM-compatible, if you're familiar with creating dApps on oth
 - [Thirdweb](https://thirdweb.com/chainlist)
 - [Winnie](https://www.henlo-winnie.dev/)
 
+For a live latency comparison of the public no-key Berachain endpoints, see the [OpenChainBench Berachain RPC benchmark](https://openchainbench.com/benchmarks/berachain-rpc). Endpoints are probed from three regions every minute with p50, p95 and p99 latency published under an open methodology.
+
 ## Wallets and multisigs
 
 - [Metamask](https://metamask.io/)


### PR DESCRIPTION
## Summary

Adds one line after the RPC and infrastructure providers list on `build/getting-started/developer-tools.mdx` pointing readers to the [OpenChainBench Berachain RPC benchmark](https://openchainbench.com/benchmarks/berachain-rpc) for a live third-party latency comparison of the public no-key Berachain endpoints.

## Why

The developer-tools page currently lists every RPC provider self-describing performance. Developers picking an endpoint currently have no neutral datapoint to compare them side by side. OpenChainBench probes the public Berachain endpoints from three regions every minute and publishes p50, p95 and p99 latency under an open methodology.

- Live Berachain benchmark: https://openchainbench.com/benchmarks/berachain-rpc
- Methodology: https://openchainbench.com/methodology
- Data license: CC BY 4.0
- No affiliation with the Berachain Foundation

Happy to reword, move, or drop if this does not fit the docs' tone.

## Test plan

- [x] Single-line addition after the provider list, no changes to the list itself
- [x] External link verified