### PR TITLE
docs: add OpenChainBench as live Berachain RPC latency reference

### DIFF
--- a/build/getting-started/developer-tools.mdx
+++ b/build/getting-started/developer-tools.mdx
@@ -44,6 +44,8 @@ Since Berachain is EVM-compatible, if you're familiar with creating dApps on oth
 - [Thirdweb](https://thirdweb.com/chainlist)
 - [Winnie](https://www.henlo-winnie.dev/)
 
+For a live latency comparison of the public keyless Berachain endpoints, see the [OpenChainBench Berachain RPC benchmark](https://openchainbench.com/benchmarks/berachain-rpc). Endpoints are probed from three regions every minute with p50, p95 and p99 latency published under an open methodology.
+
 ## Wallets and multisigs
 
 - [Metamask](https://metamask.io/)


### PR DESCRIPTION
This resubmits PR #71, originally opened by @Flotapponnier, who maintains OpenChainBench.

His personal account was incorrectly caught by GitHub's automated spam detection last week (an appeal is in progress with GitHub Support), which made the original PR invisible to reviewers. We apologize for the confusion and the extra noise. We are submitting from the project account so the change does not go stale.

The change adds one paragraph to the developer tools page: a link to the [OpenChainBench Berachain RPC benchmark](https://openchainbench.com/benchmarks/berachain-rpc), so readers can compare live latency of the public keyless endpoints. Methodology is open and the data is published under an open license.

Happy to address any feedback.