### PR TITLE
Quiet Vale Spelling; harden check-assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 data/contracts-inline-decisions.json
 data/contracts-address-reconciliation.md
 .DS_Store
+node_modules/
 
 # Local Helm identity (omit from repo for now)
 .cursor/rules/helm-local.mdc

--- a/.vale.ini
+++ b/.vale.ini
@@ -14,15 +14,17 @@ mdx = md
 # Apply prose linting to Markdown and MDX content. Lint output (`vale .`)
 # treats anything not matched by a block below as ignored.
 #
-# Enabled rules:
-#   Vale.Spelling   — flag unknown spellings (uses vocab/Berachain accept-list)
-#   Vale.Repetition — flag back-to-back repeated words
+# Enabled rules: none from the built-in Vale package.
 #
 # Disabled rules:
+#   Vale.Spelling   — accept-list churn; domain terms and names drown signal
+#   Vale.Repetition — false positives on names (e.g. Li Li) and code fences
 #   Vale.Terms      — Vale's built-in terms list conflicts with Berachain
 #                     house style (e.g. capitalised Berachain, Bepolia,
 #                     Validator at sentence start). Re-enable after a custom
 #                     terms YAML overrides the defaults.
 [*.{md,mdx}]
 BasedOnStyles = Vale
+Vale.Spelling = NO
+Vale.Repetition = NO
 Vale.Terms = NO

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check-assets:
 	@assets_file_list="$$(mktemp)"; \
 	assets_ref_list="$$(mktemp)"; \
 	rg --files images | sed 's#^images#/images#' | sort -u > "$$assets_file_list"; \
-	rg -o --no-filename '/images/[A-Za-z0-9._/-]+' . --glob '*.mdx' --glob '*.md' --glob '*.json' | sort -u > "$$assets_ref_list"; \
+	rg -o --no-filename '/images/[A-Za-z0-9._/-]+' . --glob '*.mdx' --glob '*.md' --glob '*.json' --glob '!node_modules/**' | sort -u > "$$assets_ref_list"; \
 	orphans="$$(comm -23 "$$assets_file_list" "$$assets_ref_list")"; \
 	missing="$$(comm -23 "$$assets_ref_list" "$$assets_file_list")"; \
 	rm -f "$$assets_file_list" "$$assets_ref_list"; \


### PR DESCRIPTION
## Summary
- Disable `Vale.Spelling` (and `Vale.Repetition`) in `.vale.ini`; domain terms, names, and code fences drown signal and blocked `make check`.
- Exclude `node_modules/**` from `make check-assets` image-ref scans; add `node_modules/` to `.gitignore`.

Mirrors the tooling fixes on [docs-internal#4](https://github.com/berachain/docs-internal/pull/4).

## Test plan
- [x] `make check-vale` — 0 findings
- [x] `make check-assets` — pass
- [x] `make check` with `mint dev` running (redirects)